### PR TITLE
Created lookup.cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,30 @@ A library of lightweight Salesforce Lightning components that streamline develop
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
+## sobjectMetadata.cmp
+* An extensible, markup-less component that returns an instance of LightningMetadataController.SObjectMetadata for the specified SObject
+
+    `<c:sobjectMetadata sobjectName="Account" aura:id="accountMetadataService" />`
+
+## fieldMetadata.cmp
+* An extensible, markup-less component that returns an instance of LightningMetadataController.FieldMetadata for the specified field
+
+    `<c:fieldMetadata sobjectName="Account" fieldName="Type" aura:id="accountTypeMetadataService" />`
+
 ## inputField.cmp
 * Provides a simple way to display an SObject's field as an input (editable) that automatically determines sobject-level security, field-level security, the field type, field label, etc. Attributes can be overridden to allow control over the field when needed
 
-    `<c:inputField sobjectName="Account" record="{!v.myAccount}" fieldName="Type" />`
+    `<c:inputField sobjectName="Account" fieldName="Type" record="{!v.myAccount}" />`
+
+## lookup.cmp
+* Provides lookup functionality that Salesforce does not provide for developers in LEX. This component is used by inputField.cmp for lookup fields.
+
+    `<c:lookup sobjectName="Contact" fieldName="AccountId" record="{!v.myContact}" />`
 
 ## outputField.cmp
 * Provides a simple way to display an SObject's field as an output (read-only) that automatically determines sobject-level security, field-level security, the field type, field label, etc. Attributes can be overridden to allow control over the field when needed
 
-    `<c:inputField sobjectName="Account" record="{!v.myAccount}" fieldName="Type" />`
-
+    `<c:inputField sobjectName="Account" fieldName="Type" record="{!v.myAccount}" />`
 
 ## sobjectLabel.cmp
 * Displays the localized version of the provided SObject's label

--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ A library of lightweight Salesforce Lightning components that streamline develop
 ## lookup.cmp
 * Provides lookup functionality that Salesforce does not provide for developers in LEX. This component is used by inputField.cmp for lookup fields.
 
+    Users can search for the record or choose one of the recently viewed records automatically displayed on focus
     `<c:lookup sobjectName="Contact" fieldName="AccountId" record="{!v.myContact}" />`
+
+    Polymorphic fields, like Task.WhoId, automatically display an SObject Switcher.
+    SObject-level permissions are automatically applied - only objects that the user has permission to view are displayed in the SObject Switcher.
+    `<c:lookup sobjectName="Task" fieldName="WhoId" record="{!v.myTask}" />`
+    ![lookup-task-whoid](https://user-images.githubusercontent.com/1267157/34769563-6f5b8374-f5fe-11e7-88c7-98e6fbb0ec75.gif)
+
 
 ## outputField.cmp
 * Provides a simple way to display an SObject's field as an output (read-only) that automatically determines sobject-level security, field-level security, the field type, field label, etc. Attributes can be overridden to allow control over the field when needed

--- a/src/aura/fieldMetadata/fieldMetadata.cmp
+++ b/src/aura/fieldMetadata/fieldMetadata.cmp
@@ -1,4 +1,4 @@
-<aura:component extensible="true" abstract="true" controller="LightningMetadataController">
+<aura:component extensible="true" controller="LightningMetadataController">
 
     <!-- Public Attributes -->
     <aura:attribute name="sobjectName" type="String" required="true" />

--- a/src/aura/fieldMetadata/fieldMetadata.cmp
+++ b/src/aura/fieldMetadata/fieldMetadata.cmp
@@ -1,11 +1,16 @@
 <aura:component extensible="true" controller="LightningMetadataController">
 
     <!-- Public Attributes -->
-    <aura:attribute name="sobjectName" type="String" required="true" />
-    <aura:attribute name="fieldName" type="String" required="true" />
+    <aura:attribute name="sobjectName" type="String" required="true" description="The API name of the SObject" />
+    <aura:attribute name="fieldName" type="String" required="true" description="The API name of the field"  />
+
+    <!-- Public Methods -->
+    <aura:method name="fetch" action="{!c.doInit}" description="(Optional) Callback function to use after fetching the metadata">
+        <aura:attribute name="callback" type="function"/>
+    </aura:method>
 
     <!-- Private Attributes -->
-    <aura:attribute name="fieldMetadata" type="Object" access="public" />
+    <aura:attribute name="fieldMetadata" type="Object" access="public" description="The field metadata object returned from the controller" />
 
     <!-- Handlers -->
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />

--- a/src/aura/fieldMetadata/fieldMetadataHelper.js
+++ b/src/aura/fieldMetadata/fieldMetadataHelper.js
@@ -5,6 +5,8 @@
 
         if(!sobjectName || !fieldName) return;
 
+        var params = event.getParam('arguments');
+
         var action = component.get('c.getFieldMetadata');
         action.setParams({
             'sobjectName': component.get('v.sobjectName'),
@@ -13,8 +15,11 @@
         action.setStorable();
         action.setCallback(this, function(response) {
             if(response.getState() === 'SUCCESS') {
-                component.set('v.fieldMetadata', response.getReturnValue());
-                component.set('v.label', response.getReturnValue().label);
+                var fieldMetadata = response.getReturnValue();
+                component.set('v.fieldMetadata', fieldMetadata);
+                component.set('v.label', fieldMetadata.label);
+
+                if(params) params.callback(null, fieldMetadata);
             } else if(response.getState() === 'ERROR') {
                 this.processCallbackErrors(response);
             }

--- a/src/aura/inputField/inputField.cmp
+++ b/src/aura/inputField/inputField.cmp
@@ -127,7 +127,9 @@
 
                 <!-- REFERENCE -->
                 <aura:if isTrue="{!v.displayType == 'REFERENCE'}">
-                    <c:lookup sobjectName="{!v.sobjectName}" fieldName="{!v.fieldName}" required="{!v.required}" disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled)}" />
+                    <c:lookup sobjectName="{!v.sobjectName}" fieldName="{!v.fieldName}" required="{!v.required}" disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled)}"
+                        record="{!v.record}"
+                    />
                 </aura:if>
 
                 <!-- STRING -->

--- a/src/aura/inputField/inputField.cmp
+++ b/src/aura/inputField/inputField.cmp
@@ -41,7 +41,6 @@
                 <!-- COMBOBOX - TODO -->
                 <!-- DATACATEGORYGROUPREFERENCE - TODO -->
                 <!-- ID - TODO -->
-                <!-- REFERENCE - TODO -->
                 <!-- TIME - TODO -->
 
                 <!-- BOOLEAN -->
@@ -124,6 +123,11 @@
                     <ui:inputPhone aura:id="inputField" value="{!v.fieldValue}" required="{!v.required}" disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled)}" class="slds-input" maxlength="{!v.fieldMetadata.maxLength}"
                         blur="{!c.handleBlur}"
                     />
+                </aura:if>
+
+                <!-- REFERENCE -->
+                <aura:if isTrue="{!v.displayType == 'REFERENCE'}">
+                    <c:lookup sobjectName="Account" fieldName="{!v.fieldName}" />
                 </aura:if>
 
                 <!-- STRING -->

--- a/src/aura/inputField/inputField.cmp
+++ b/src/aura/inputField/inputField.cmp
@@ -127,7 +127,7 @@
 
                 <!-- REFERENCE -->
                 <aura:if isTrue="{!v.displayType == 'REFERENCE'}">
-                    <c:lookup sobjectName="{!v.sobjectName}" fieldName="{!v.fieldName}" />
+                    <c:lookup sobjectName="{!v.sobjectName}" fieldName="{!v.fieldName}" required="{!v.required}" disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled)}" />
                 </aura:if>
 
                 <!-- STRING -->

--- a/src/aura/inputField/inputField.cmp
+++ b/src/aura/inputField/inputField.cmp
@@ -127,7 +127,7 @@
 
                 <!-- REFERENCE -->
                 <aura:if isTrue="{!v.displayType == 'REFERENCE'}">
-                    <c:lookup sobjectName="Account" fieldName="{!v.fieldName}" />
+                    <c:lookup sobjectName="{!v.sobjectName}" fieldName="{!v.fieldName}" />
                 </aura:if>
 
                 <!-- STRING -->

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,8 +1,10 @@
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
     <aura:attribute name="childRecord" type="SObject" default="{}" />
+    <aura:attribute name="disabled" type="Boolean" description="(Optional) Disables the input field" />
+    <aura:attribute name="required" type="Boolean" description="(Optional) Marks the field as required (true) or optional (false)" />
+    <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
 
     <!-- Private Selected Record Attributes -->
     <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
@@ -34,10 +36,11 @@
                                     aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
                                     aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
                                     placeholder="{! if(empty(v.parentSObjectMetadata), '', 'Search ' + v.parentSObjectMetadata.labelPlural) }"
+                                    required="{!or(v.required, v.fieldMetadata.required)}"
+                                    disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled, empty(v.parentSObjectMetadata))}"
                                     onkeyup="{!c.fetchSearchResults}" onfocus="{!c.fetchSearchResults}"
-                                    disabled="{!empty(v.parentSObjectMetadata)}"
                                 />
-                                <!-- onblur="{!c.hideSearchResults}" -->
+                                <!-- onblur="{!c.hideSearchResults}" --> <!--TODO fix hiding onblur-->
                                 <span class="slds-icon_container slds-icon-utility-search slds-input__icon slds-input__icon_right">
                                     <lightning:icon iconName="utility:search" size="x-small" />
                                 </span>

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -96,7 +96,7 @@
                         <div id="listbox-unique-id" role="listbox">
                             <ul role="presentation" class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-is-open" style="display:block; min-width:auto; max-width:100%; width:100%;">
                                 <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
-                                    <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
+                                    <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.parentRecordSelected}">
                                         <span role="option" class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta">
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -96,7 +96,7 @@
                         <div id="listbox-unique-id" role="listbox">
                             <ul role="presentation" class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-is-open" style="display:block; min-width:auto; max-width:100%; width:100%;">
                                 <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
-                                    <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.parentRecordSelected}">
+                                    <li role="presentation" class="slds-listbox__item" data-selectedparentindex="{#i}" onclick="{!c.parentRecordSelected}">
                                         <span role="option" class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta">
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -10,55 +10,88 @@
     <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
     <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
 
+    <!-- Private SObject Selector Attributes -->
+    <aura:attribute Name="showSObjectSelector" type="Boolean" access="private" default="false" />
+    <aura:attribute name="parentSObjectName" type="String" access="private" />
+    <aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
+
     <!-- Private Search Result Attributes -->
     <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
     <aura:attribute Name="searchResults" type="Object[]" access="private" />
 
-    <!-- Private Metadata Attributes -->
-    <aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
-
     <!-- Handlers -->
     <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.doInit}" />
+    <aura:handler name="change" value="{!v.parentSObjectName}" action="{!c.fetchParentSObjectMetadata}" />
 
     <!-- Markup -->
     <c:sobjectMetadata aura:id="sobjectMetadataService" />
 
     <div class="slds-form-element">
         <div class="slds-form-element__control">
-            <div class="slds-combobox_container slds-has-inline-listbox">
-                <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click slds-is-open"
-                    aria-expanded="true" aria-haspopup="listbox" role="combobox" style="width:95%">
-
-                    <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right">
-                        <div>
-                            <aura:if isTrue="{!empty(v.selectedRecord)}">
-                                <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
-                                    aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
-                                    aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
-                                    placeholder="{! if(empty(v.parentSObjectMetadata), '', 'Search ' + v.parentSObjectMetadata.labelPlural) }"
-                                    required="{!or(v.required, v.fieldMetadata.required)}"
-                                    disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled, empty(v.parentSObjectMetadata))}"
-                                    onkeyup="{!c.fetchSearchResults}" onfocus="{!c.fetchSearchResults}"
-                                />
-                                <!-- onblur="{!c.hideSearchResults}" --> <!--TODO fix hiding onblur-->
-                                <span class="slds-icon_container slds-icon-utility-search slds-input__icon slds-input__icon_right">
-                                    <lightning:icon iconName="utility:search" size="x-small" />
-                                </span>
-                                <aura:set attribute="else">
-                                    <span class="slds-pill slds-pill_link fullWidth">
-                                        <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
-                                            <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="x-small" />
-                                            <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
-                                        </a>
-                                        <button onclick="{!c.clearSelection}" class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove">
-                                            <lightning:icon iconName="utility:close" size="small" alternativeText="Press delete or backspace to remove" />
-                                            <span class="slds-assistive-text">Remove</span>
-                                        </button>
-                                    </span>
-                                </aura:set>
-                            </aura:if>
-                       	</div>
+            <div class="slds-combobox_container slds-has-object-switcher">
+                <!-- SObject Switcher -->
+                <aura:if isTrue="{! and(empty(v.selectedRecord), v.fieldMetadata.relationshipReferences.length > 1)}">
+                    <div class="slds-listbox_object-switcher slds-dropdown-trigger slds-dropdown-trigger_click slds-is-open">
+                        <button class="slds-button slds-button_icon" aria-haspopup="true" title="Select object to search in" onclick="{!c.toggleParentSObjectSelector}">
+                            <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="small" />
+                            <lightning:icon iconName="utility:down" size="x-small" />
+                        </button>
+                        <aura:if isTrue="{!v.showSObjectSelector}">
+                            <div class="slds-dropdown slds-dropdown_left slds-dropdown_small">
+                                <ul class="slds-dropdown__list" role="menu">
+                                    <aura:iteration items="{!v.fieldMetadata.relationshipReferences}" var="relationshipReference">
+                                        <aura:if isTrue="{!relationshipReference.isAccessible}">
+                                            <li class="slds-dropdown__item slds-is-selected" role="presentation">
+                                                <a href="javascript:void(0);" role="menuitemcheckbox" aria-checked="true" tabindex="0" data-sobjectname="{!relationshipReference.name}" onclick="{!c.selectParentSObject}">
+                                                    <span class="slds-truncate" title="{!relationshipReference.labelPlural}">
+                                                        <lightning:icon iconName="{!relationshipReference.tabIcon}" size="large" />
+                                                        &nbsp;{!relationshipReference.labelPlural}
+                                                    </span>
+                                                </a>
+                                            </li>
+                                        </aura:if>
+                                    </aura:iteration>
+                                </ul>
+                            </div>
+                        </aura:if>
                     </div>
+                </aura:if>
+                <!-- Search Box -->
+                <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click" aria-expanded="false" aria-haspopup="listbox" role="combobox">
+                    <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right" role="none">
+                        <aura:if isTrue="{!empty(v.selectedRecord)}">
+                            <input
+                                aria-autocomplete="list"
+                                aria-controls="listbox-unique-id"
+                                autocomplete="off"
+                                class="slds-input slds-combobox__input"
+                                disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled, empty(v.parentSObjectMetadata))}"
+                                id="combobox-unique-id"
+                                onfocus="{!c.fetchSearchResults}"
+                                onkeyup="{!c.fetchSearchResults}"
+                                placeholder="{! if(empty(v.parentSObjectMetadata), '', 'Search ' + v.parentSObjectMetadata.labelPlural) }"
+                                required="{!or(v.required, v.fieldMetadata.required)}"
+                                role="textbox"
+                                type="text"
+                            />
+                            <span class="slds-icon_container slds-icon-utility-search slds-input__icon slds-input__icon_right">
+                                <lightning:icon iconName="utility:search" size="x-small" />
+                            </span>
+                            <aura:set attribute="else">
+                                <span class="slds-pill slds-pill_link">
+                                    <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
+                                        <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="x-small" />
+                                        <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
+                                    </a>
+                                    <button class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove" onclick="{!c.clearSelection}" >
+                                        <lightning:icon iconName="utility:close" size="small" />
+                                        <span class="slds-assistive-text">Remove</span>
+                                    </button>
+                                </span>
+                            </aura:set>
+                        </aura:if>
+                    </div>
+                    <!-- Search Results -->
                     <aura:if isTrue="{!and(v.showSearchResults, greaterthan(v.searchResults.length, 0))}">
                         <div id="listbox-unique-id" role="listbox">
                             <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid" role="presentation"

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,31 +1,34 @@
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <aura:attribute name="sobjectName" type="String" description="Name of Object to be searched" />
-    <aura:attribute name="fieldName" type="String" default="Id" description="API Name of field, to be returned from component" />
-    <aura:attribute name="field_API_text" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field of text shown to users in the search results" />
-    <aura:attribute name="field_API_search" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="API Name of field to be searched" />
-    <aura:attribute name="limit" type="Integer" default="5" description="Total number of record to be returned" />
+    <aura:attribute name="sobjectName" type="String" description="SObject type to be searched" />
+    <aura:attribute name="displayTextFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field shown to users in the search results" />
+    <aura:attribute name="searchFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field to be searched" />
+    <aura:attribute name="limit" type="Integer" default="5" description="Total number of records to return" />
     <aura:attribute name="record" type="SObject" default="{}" />
+
+    <!-- Private Selected Record Attributes -->
+    <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
+    <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
 
     <!-- Public UI Attributes -->
     <aura:attribute name="lookupIcon" type="String" default="{!v.fieldMetadata.sobjectMetadata.tabIcon}" />
     <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.fieldMetadata.sobjectMetadata.labelPlural }" />
 
     <!-- Private Search Result Attributes -->
-    <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
-    <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
-    <aura:attribute Name="searchResults" type="object[]" access="private" />
+    <aura:attribute Name="searchResults" type="Object[]" access="private" />
 
     <!-- Private Cached Search Attributes -->
     <aura:attribute name="last_SearchText" type="String" access="private" />
-    <aura:attribute name="last_ServerResult" type="object[]" access="private" />
+    <aura:attribute name="last_ServerResult" type="Object[]" access="private" />
 
+    <!-- Private Inherited Attributes -->
+    <aura:attribute name="fieldName" type="String" access="private" default="Id" />
 [nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
 [tabIcon = {!v.fieldMetadata.sobjectMetadata.tabIcon}]
 [fieldName = {!v.fieldName}]
-[field_API_text = {!v.field_API_text}]
-[field_API_search = {!v.field_API_search}]
+[displayTextFieldName = {!v.displayTextFieldName}]
+[searchFieldName = {!v.searchFieldName}]
 <br />
 [selectedRecord.recordId = {!v.selectedRecord.recordId}]
 [last_SearchText = {!v.last_SearchText}]
@@ -38,23 +41,23 @@
                     <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right">
                         <div>
                             <aura:if isTrue="{!empty(v.selectedRecord)}">
-                                    <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
-                                            aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
-                                            aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
-                                            placeholder="{!v.placeholder}"
-                                            onkeyup="{!c.fetchSearchResults}" />
-                                    <aura:set attribute="else">
-                                        <span class="slds-pill slds-pill_link fullWidth">
-                                            <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
-                                                <lightning:icon iconName="{#v.lookupIcon}" size="x-small" />
-                                                <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
-                                            </a>
-                                            <button onclick="{!c.clearSelection}" class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove">
-                                                <lightning:icon iconName="utility:close" size="small" alternativeText="Press delete or backspace to remove" />
-                                                <span class="slds-assistive-text">Remove</span>
-                                            </button>
-                                        </span>
-                                    </aura:set>
+                                <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
+                                    aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
+                                    aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
+                                    placeholder="{!v.placeholder}" onkeyup="{!c.fetchSearchResults}"
+                                />
+                                <aura:set attribute="else">
+                                    <span class="slds-pill slds-pill_link fullWidth">
+                                        <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
+                                            <lightning:icon iconName="{#v.lookupIcon}" size="x-small" />
+                                            <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
+                                        </a>
+                                        <button onclick="{!c.clearSelection}" class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove">
+                                            <lightning:icon iconName="utility:close" size="small" alternativeText="Press delete or backspace to remove" />
+                                            <span class="slds-assistive-text">Remove</span>
+                                        </button>
+                                    </span>
+                                </aura:set>
                             </aura:if>
                        	</div>
                     </div>
@@ -65,8 +68,8 @@
                                 <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
                                     <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
                                         <span id="{# 'listbox-option-unique-id-' + i + 1}"
-                                              class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
-                                              role="option">
+                                            class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
+                                            role="option">
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >
                                                     <lightning:icon iconName="{#v.lookupIcon}" size="small" />

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -7,19 +7,22 @@
     <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
 
     <!-- Private Selected Record Attributes -->
-    <aura:attribute Name="selectedParentRecord" type="SObject" access="private" />
+    <aura:attribute name="selectedParentRecordId" type="Id" access="private" />
+    <aura:attribute name="selectedParentRecord" type="SObject" access="private" />
 
     <!-- Private SObject Selector Attributes -->
-    <aura:attribute Name="showSObjectSelector" type="Boolean" access="private" default="false" />
+    <aura:attribute name="showSObjectSelector" type="Boolean" access="private" default="false" />
     <aura:attribute name="parentSObjectName" type="String" access="private" />
     <aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
 
     <!-- Private Search Result Attributes -->
-    <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
-    <aura:attribute Name="searchResults" type="Object[]" access="private" />
+    <aura:attribute name="showSearchResults" type="Boolean" access="private" default="false" />
+    <aura:attribute name="searchResults" type="Object[]" access="private" />
 
     <!-- Handlers -->
-    <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.doInit}" />
+    <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
+    <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.parseFieldMetadata}" />
+    <aura:handler name="change" value="{!v.selectedParentRecordId}" action="{!c.loadSelectedParentRecord}" />
     <aura:handler name="change" value="{!v.parentSObjectName}" action="{!c.loadParentSObjectMetadata}" />
 
     <!-- Markup -->

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -21,11 +21,9 @@
 
     <!-- Handlers -->
     <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.doInit}" />
-    <aura:handler name="change" value="{!v.parentSObjectName}" action="{!c.fetchParentSObjectMetadata}" />
+    <aura:handler name="change" value="{!v.parentSObjectName}" action="{!c.loadParentSObjectMetadata}" />
 
     <!-- Markup -->
-    <c:sobjectMetadata aura:id="sobjectMetadataService" />
-
     <div class="slds-form-element">
         <div class="slds-form-element__control">
             <div class="slds-combobox_container slds-has-object-switcher">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -96,18 +96,15 @@
                                 style="display:block; min-width:auto; max-width:100%; width:100%;">
                                 <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
                                     <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
-                                        <span id="{# 'listbox-option-unique-id-' + i + 1}"
-                                            class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
-                                            role="option"
-                                        >
+                                        <span role="option" class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta">
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >
                                                     <lightning:icon iconName="{#v.parentSObjectMetadata.tabIcon}" size="small" />
-                                                    <span class="slds-assistive-text">{#v.parentSObjectMetadata.label}</span>
+                                                    <span class="slds-assistive-text">{!v.parentSObjectMetadata.label}</span>
                                                 </span>
                                             </span>
                                             <span class="slds-media__body">
-                                                <span class="slds-listbox__option-text slds-listbox__option-text_entity">{#matchingRecord.displayText}</span>
+                                                <span class="slds-listbox__option-text slds-listbox__option-text_entity">{!matchingRecord.displayText}</span>
                                             </span>
                                         </span>
                                     </li>

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,16 +1,6 @@
-
-
-
-
-
-<!-- http://biswajeetsamal.com/blog/salesforce-generic-sobject-lightning-lookup-component/ -->
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <!-- <aura:attribute name="parentSObjectName" type="String" description="SObject type to be searched" />
-    <aura:attribute name="displayTextFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field shown to users in the search results" />
-    <aura:attribute name="searchFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field to be searched" />
-    <aura:attribute name="childRecordLookupFieldName" type="String" required="false" description="The lookup field on the child SObject" /> -->
     <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
     <aura:attribute name="childRecord" type="SObject" default="{}" />
 
@@ -19,43 +9,22 @@
     <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
 
     <!-- Public UI Attributes -->
-    <aura:attribute name="lookupIcon" type="String" default="{!v.fieldMetadata.sobjectMetadata.tabIcon}" />
+    <!-- <aura:attribute name="lookupIcon" type="String" default="{!v.parentSObjectMetadata.tabIcon}" /> -->
     <aura:attribute name="searchText" type="String" />
-    <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.fieldMetadata.sobjectMetadata.labelPlural }" />
+    <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.parentSObjectMetadata.labelPlural }" />
 
     <!-- Private Search Result Attributes -->
     <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
     <aura:attribute Name="searchResults" type="Object[]" access="private" />
-    <!-- <aura:attribute Name="recentlyViewRecords" type="Object[]" access="private" /> -->
 
-
-<aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
-    <!-- Private Inherited Attributes -->
-    <!-- <aura:attribute name="sobjectName" type="String" access="private" default="{!v.parentSObjectName}" />
-    <aura:attribute name="fieldName" type="String" access="private" default="Id" /> -->
+    <!-- Private Metadata Attributes -->
+    <aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
 
     <!-- Handlers -->
-    <!-- <aura:handler name="init" value="{!this}" action="{!c.doInit}" /> -->
     <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.doInit}" />
-<!-- [parentSObjectMetadata nameField = {!v.parentSObjectMetadata.nameField}] -->
-<c:sobjectMetadata sobjectName="" aura:id="parentSObjectMetadataCmp" />
-<div style="border:1px solid red">
-    {!v.parentSObjectMetadata.name}
-    </div>
-<!-- relationship test [{!v.fieldMetadata.relationshipReferences.length}] -->
-    <aura:iteration items="{!v.fieldMetadata.relationshipReferences}" var="relationship">
-        [{!relationship}]
-    </aura:iteration>
-    <!-- [relationshipReferences = {!v.fieldMetadata.relationshipReferences}] -->
-<!-- [nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
-[tabIcon = {!v.fieldMetadata.sobjectMetadata.tabIcon}]
-[fieldName = {!v.fieldName}]
-[displayTextFieldName = {!v.displayTextFieldName}]
-[searchFieldName = {!v.searchFieldName}] -->
-<br />
-[selectedRecordId = {!v.selectedRecordId}]
-<br />
-[childRecord.AccountId = {!v.childRecord.AccountId}]
+
+    <!-- Markup -->
+    <c:sobjectMetadata aura:id="sobjectMetadataService" />
 
     <div class="slds-form-element">
         <div class="slds-form-element__control">
@@ -69,7 +38,7 @@
                                 <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
                                     aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
                                     aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
-                                    placeholder="{!v.placeholder}"
+                                    placeholder="{! 'Search ' + v.parentSObjectMetadata.labelPlural }"
                                     onkeyup="{!c.fetchSearchResults}" onfocus="{!c.fetchSearchResults}"
                                     value="{#v.searchText}"
                                 />
@@ -80,7 +49,7 @@
                                 <aura:set attribute="else">
                                     <span class="slds-pill slds-pill_link fullWidth">
                                         <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
-                                            <lightning:icon iconName="{#v.lookupIcon}" size="x-small" />
+                                            <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="x-small" />
                                             <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
                                         </a>
                                         <button onclick="{!c.clearSelection}" class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove">
@@ -103,8 +72,8 @@
                                             role="option">
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >
-                                                    <lightning:icon iconName="{#v.lookupIcon}" size="small" />
-                                                    <span class="slds-assistive-text">{#v.sobjectName}</span>
+                                                    <lightning:icon iconName="{#v.parentSObjectMetadata.tabIcon}" size="small" />
+                                                    <span class="slds-assistive-text">{#v.parentSObjectMetadata.label}</span>
                                                 </span>
                                             </span>
                                             <span class="slds-media__body singleRow">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,7 +1,7 @@
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <aura:attribute name="childRecord" type="SObject" default="{}" />
+    <aura:attribute name="record" type="SObject" default="{}" />
     <aura:attribute name="disabled" type="Boolean" description="(Optional) Disables the input field" />
     <aura:attribute name="required" type="Boolean" description="(Optional) Marks the field as required (true) or optional (false)" />
     <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -8,11 +8,6 @@
     <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
     <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
 
-    <!-- Public UI Attributes -->
-    <!-- <aura:attribute name="lookupIcon" type="String" default="{!v.parentSObjectMetadata.tabIcon}" /> -->
-    <aura:attribute name="searchText" type="String" />
-    <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.parentSObjectMetadata.labelPlural }" />
-
     <!-- Private Search Result Attributes -->
     <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
     <aura:attribute Name="searchResults" type="Object[]" access="private" />
@@ -38,9 +33,9 @@
                                 <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
                                     aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
                                     aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
-                                    placeholder="{! 'Search ' + v.parentSObjectMetadata.labelPlural }"
+                                    placeholder="{! if(empty(v.parentSObjectMetadata), '', 'Search ' + v.parentSObjectMetadata.labelPlural) }"
                                     onkeyup="{!c.fetchSearchResults}" onfocus="{!c.fetchSearchResults}"
-                                    value="{#v.searchText}"
+                                    disabled="{!empty(v.parentSObjectMetadata)}"
                                 />
                                 <!-- onblur="{!c.hideSearchResults}" -->
                                 <span class="slds-icon_container slds-icon-utility-search slds-input__icon slds-input__icon_right">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -92,8 +92,7 @@
                     <!-- Search Results -->
                     <aura:if isTrue="{!and(v.showSearchResults, greaterthan(v.searchResults.length, 0))}">
                         <div id="listbox-unique-id" role="listbox">
-                            <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid" role="presentation"
-                                style="display:block; min-width:auto; max-width:100%; width:100%;">
+                            <ul role="presentation" class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid slds-is-open" style="display:block; min-width:auto; max-width:100%; width:100%;">
                                 <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
                                     <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
                                         <span role="option" class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,0 +1,89 @@
+<aura:component extends="c.fieldMetadata" controller="LookupController">
+
+    <!-- Public Config Attributes -->
+    <aura:attribute name="sobjectName" type="String" description="Name of Object to be searched" />
+    <aura:attribute name="fieldName" type="String" default="Id" description="API Name of field, to be returned from component" />
+    <aura:attribute name="field_API_text" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field of text shown to users in the search results" />
+    <aura:attribute name="field_API_search" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="API Name of field to be searched" />
+    <aura:attribute name="limit" type="Integer" default="5" description="Total number of record to be returned" />
+    <aura:attribute name="record" type="SObject" default="{}" />
+
+    <!-- Public UI Attributes -->
+    <aura:attribute name="lookupIcon" type="String" default="{!v.fieldMetadata.sobjectMetadata.tabIcon}" />
+    <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.fieldMetadata.sobjectMetadata.labelPlural }" />
+
+    <!-- Private Search Result Attributes -->
+    <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
+    <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
+    <aura:attribute Name="searchResults" type="object[]" access="private" />
+
+    <!-- Private Cached Search Attributes -->
+    <aura:attribute name="last_SearchText" type="String" access="private" />
+    <aura:attribute name="last_ServerResult" type="object[]" access="private" />
+
+[nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
+[tabIcon = {!v.fieldMetadata.sobjectMetadata.tabIcon}]
+[fieldName = {!v.fieldName}]
+[field_API_text = {!v.field_API_text}]
+[field_API_search = {!v.field_API_search}]
+<br />
+[selectedRecord.recordId = {!v.selectedRecord.recordId}]
+[last_SearchText = {!v.last_SearchText}]
+
+    <div class="slds-form-element">
+        <div class="slds-form-element__control">
+            <div class="slds-combobox_container slds-has-inline-listbox">
+                <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click slds-is-open"
+                    aria-expanded="true" aria-haspopup="listbox" role="combobox" style="width:95%">
+                    <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right">
+                        <div>
+                            <aura:if isTrue="{!empty(v.selectedRecord)}">
+                                    <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
+                                            aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
+                                            aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
+                                            placeholder="{!v.placeholder}"
+                                            onkeyup="{!c.fetchSearchResults}" />
+                                    <aura:set attribute="else">
+                                        <span class="slds-pill slds-pill_link fullWidth">
+                                            <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
+                                                <lightning:icon iconName="{#v.lookupIcon}" size="x-small" />
+                                                <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
+                                            </a>
+                                            <button onclick="{!c.clearSelection}" class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove">
+                                                <lightning:icon iconName="utility:close" size="small" alternativeText="Press delete or backspace to remove" />
+                                                <span class="slds-assistive-text">Remove</span>
+                                            </button>
+                                        </span>
+                                    </aura:set>
+                            </aura:if>
+                       	</div>
+                    </div>
+                    <aura:if isTrue="{!greaterthanorequal(v.searchResults.length, 1)}">
+                        <div id="listbox-unique-id" role="listbox">
+                            <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid" role="presentation"
+                                style="display:block; min-width:auto; max-width:100%; width:100%;">
+                                <aura:iteration items="{!v.searchResults}" var="matchingRecord" indexVar="i">
+                                    <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
+                                        <span id="{# 'listbox-option-unique-id-' + i + 1}"
+                                              class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
+                                              role="option">
+                                            <span class="slds-media__figure optionIcon">
+                                                <span class="slds-icon_container" >
+                                                    <lightning:icon iconName="{#v.lookupIcon}" size="small" />
+                                                    <span class="slds-assistive-text">{#v.sobjectName}</span>
+                                                </span>
+                                            </span>
+                                            <span class="slds-media__body singleRow">
+                                                <span class="optionTitle slds-listbox__option-text slds-listbox__option-text_entity">{#matchingRecord.displayText}</span>
+                                            </span>
+                                        </span>
+                                    </li>
+                                </aura:iteration>
+                            </ul>
+                        </div>
+                    </aura:if>
+                </div>
+            </div>
+        </div>
+    </div>
+</aura:component>

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -65,7 +65,7 @@
                                 aria-controls="listbox-unique-id"
                                 autocomplete="off"
                                 class="slds-input slds-combobox__input"
-                                disabled="{!or(v.fieldMetadata.isUpdateable == false, v.disabled, empty(v.parentSObjectMetadata))}"
+                                disabled="{!or(empty(v.parentSObjectMetadata), v.fieldMetadata.isUpdateable == false, v.disabled)}"
                                 id="combobox-unique-id"
                                 onfocus="{!c.fetchSearchResults}"
                                 onkeyup="{!c.fetchSearchResults}"

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -7,8 +7,7 @@
     <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
 
     <!-- Private Selected Record Attributes -->
-    <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
-    <aura:attribute Name="selectedRecordId" type="Id" access="public" description="This attribute can be used by parent component to read selected record" />
+    <aura:attribute Name="selectedParentRecord" type="SObject" access="private" />
 
     <!-- Private SObject Selector Attributes -->
     <aura:attribute Name="showSObjectSelector" type="Boolean" access="private" default="false" />
@@ -28,7 +27,7 @@
         <div class="slds-form-element__control">
             <div class="slds-combobox_container slds-has-object-switcher">
                 <!-- SObject Switcher -->
-                <aura:if isTrue="{! and(empty(v.selectedRecord), v.fieldMetadata.relationshipReferences.length > 1)}">
+                <aura:if isTrue="{! and(empty(v.selectedParentRecord), v.fieldMetadata.relationshipReferences.length > 1)}">
                     <div class="slds-listbox_object-switcher slds-dropdown-trigger slds-dropdown-trigger_click slds-is-open">
                         <button class="slds-button slds-button_icon" aria-haspopup="true" title="Select object to search in" onclick="{!c.toggleParentSObjectSelector}">
                             <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="small" />
@@ -57,7 +56,7 @@
                 <!-- Search Box -->
                 <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click" aria-expanded="false" aria-haspopup="listbox" role="combobox">
                     <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right" role="none">
-                        <aura:if isTrue="{!empty(v.selectedRecord)}">
+                        <aura:if isTrue="{!empty(v.selectedParentRecord)}">
                             <input
                                 aria-autocomplete="list"
                                 aria-controls="listbox-unique-id"
@@ -77,9 +76,9 @@
                             </span>
                             <aura:set attribute="else">
                                 <span class="slds-pill slds-pill_link">
-                                    <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
+                                    <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedParentRecord.displayText}">
                                         <lightning:icon iconName="{!v.parentSObjectMetadata.tabIcon}" size="x-small" />
-                                        <span class="slds-pill__label slds-p-left_x-small">{#v.selectedRecord.displayText}</span>
+                                        <span class="slds-pill__label slds-p-left_x-small">{#v.selectedParentRecord.displayText}</span>
                                     </a>
                                     <button class="slds-button slds-button_icon slds-button_icon slds-pill__remove" title="Remove" onclick="{!c.clearSelection}" >
                                         <lightning:icon iconName="utility:close" size="small" />

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,11 +1,17 @@
+
+
+
+
+
+<!-- http://biswajeetsamal.com/blog/salesforce-generic-sobject-lightning-lookup-component/ -->
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <aura:attribute name="parentSObjectName" type="String" description="SObject type to be searched" />
+    <!-- <aura:attribute name="parentSObjectName" type="String" description="SObject type to be searched" />
     <aura:attribute name="displayTextFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field shown to users in the search results" />
     <aura:attribute name="searchFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field to be searched" />
+    <aura:attribute name="childRecordLookupFieldName" type="String" required="false" description="The lookup field on the child SObject" /> -->
     <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
-    <aura:attribute name="childRecordLookupFieldName" type="String" required="true" description="The lookup field on the child SObject" />
     <aura:attribute name="childRecord" type="SObject" default="{}" />
 
     <!-- Private Selected Record Attributes -->
@@ -20,17 +26,32 @@
     <!-- Private Search Result Attributes -->
     <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
     <aura:attribute Name="searchResults" type="Object[]" access="private" />
-    <aura:attribute Name="recentlyViewRecords" type="Object[]" access="private" />
+    <!-- <aura:attribute Name="recentlyViewRecords" type="Object[]" access="private" /> -->
 
+
+<aura:attribute name="parentSObjectMetadata" type="Object" access="private" />
     <!-- Private Inherited Attributes -->
-    <aura:attribute name="sobjectName" type="String" access="private" default="{!v.parentSObjectName}" />
-    <aura:attribute name="fieldName" type="String" access="private" default="Id" />
-    [relationshipReferences = {!v.fieldMetadata.relationshipReferences}]
-[nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
+    <!-- <aura:attribute name="sobjectName" type="String" access="private" default="{!v.parentSObjectName}" />
+    <aura:attribute name="fieldName" type="String" access="private" default="Id" /> -->
+
+    <!-- Handlers -->
+    <!-- <aura:handler name="init" value="{!this}" action="{!c.doInit}" /> -->
+    <aura:handler name="change" value="{!v.fieldMetadata}" action="{!c.doInit}" />
+<!-- [parentSObjectMetadata nameField = {!v.parentSObjectMetadata.nameField}] -->
+<c:sobjectMetadata sobjectName="" aura:id="parentSObjectMetadataCmp" />
+<div style="border:1px solid red">
+    {!v.parentSObjectMetadata.name}
+    </div>
+<!-- relationship test [{!v.fieldMetadata.relationshipReferences.length}] -->
+    <aura:iteration items="{!v.fieldMetadata.relationshipReferences}" var="relationship">
+        [{!relationship}]
+    </aura:iteration>
+    <!-- [relationshipReferences = {!v.fieldMetadata.relationshipReferences}] -->
+<!-- [nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
 [tabIcon = {!v.fieldMetadata.sobjectMetadata.tabIcon}]
 [fieldName = {!v.fieldName}]
 [displayTextFieldName = {!v.displayTextFieldName}]
-[searchFieldName = {!v.searchFieldName}]
+[searchFieldName = {!v.searchFieldName}] -->
 <br />
 [selectedRecordId = {!v.selectedRecordId}]
 <br />
@@ -41,6 +62,7 @@
             <div class="slds-combobox_container slds-has-inline-listbox">
                 <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click slds-is-open"
                     aria-expanded="true" aria-haspopup="listbox" role="combobox" style="width:95%">
+
                     <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right">
                         <div>
                             <aura:if isTrue="{!empty(v.selectedRecord)}">
@@ -52,6 +74,9 @@
                                     value="{#v.searchText}"
                                 />
                                 <!-- onblur="{!c.hideSearchResults}" -->
+                                <span class="slds-icon_container slds-icon-utility-search slds-input__icon slds-input__icon_right">
+                                    <lightning:icon iconName="utility:search" size="x-small" />
+                                </span>
                                 <aura:set attribute="else">
                                     <span class="slds-pill slds-pill_link fullWidth">
                                         <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -1,11 +1,12 @@
 <aura:component extends="c.fieldMetadata" controller="LookupController">
 
     <!-- Public Config Attributes -->
-    <aura:attribute name="sobjectName" type="String" description="SObject type to be searched" />
+    <aura:attribute name="parentSObjectName" type="String" description="SObject type to be searched" />
     <aura:attribute name="displayTextFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field shown to users in the search results" />
     <aura:attribute name="searchFieldName" type="String" default="{!v.fieldMetadata.sobjectMetadata.nameField}" description="Field to be searched" />
-    <aura:attribute name="limit" type="Integer" default="5" description="Total number of records to return" />
-    <aura:attribute name="record" type="SObject" default="{}" />
+    <aura:attribute name="limitCount" type="Integer" default="5" description="Total number of records to return" />
+    <aura:attribute name="childRecordLookupFieldName" type="String" required="true" description="The lookup field on the child SObject" />
+    <aura:attribute name="childRecord" type="SObject" default="{}" />
 
     <!-- Private Selected Record Attributes -->
     <aura:attribute Name="selectedRecord" type="SObject" access="public" description="This attribute can be used by parent component to read selected record" />
@@ -13,25 +14,27 @@
 
     <!-- Public UI Attributes -->
     <aura:attribute name="lookupIcon" type="String" default="{!v.fieldMetadata.sobjectMetadata.tabIcon}" />
+    <aura:attribute name="searchText" type="String" />
     <aura:attribute name="placeholder" type="String" default="{! 'Search ' + v.fieldMetadata.sobjectMetadata.labelPlural }" />
 
     <!-- Private Search Result Attributes -->
+    <aura:attribute Name="showSearchResults" type="Boolean" access="private" default="false" />
     <aura:attribute Name="searchResults" type="Object[]" access="private" />
-
-    <!-- Private Cached Search Attributes -->
-    <aura:attribute name="last_SearchText" type="String" access="private" />
-    <aura:attribute name="last_ServerResult" type="Object[]" access="private" />
+    <aura:attribute Name="recentlyViewRecords" type="Object[]" access="private" />
 
     <!-- Private Inherited Attributes -->
+    <aura:attribute name="sobjectName" type="String" access="private" default="{!v.parentSObjectName}" />
     <aura:attribute name="fieldName" type="String" access="private" default="Id" />
+    [relationshipReferences = {!v.fieldMetadata.relationshipReferences}]
 [nameField = {!v.fieldMetadata.sobjectMetadata.nameField}]
 [tabIcon = {!v.fieldMetadata.sobjectMetadata.tabIcon}]
 [fieldName = {!v.fieldName}]
 [displayTextFieldName = {!v.displayTextFieldName}]
 [searchFieldName = {!v.searchFieldName}]
 <br />
-[selectedRecord.recordId = {!v.selectedRecord.recordId}]
-[last_SearchText = {!v.last_SearchText}]
+[selectedRecordId = {!v.selectedRecordId}]
+<br />
+[childRecord.AccountId = {!v.childRecord.AccountId}]
 
     <div class="slds-form-element">
         <div class="slds-form-element__control">
@@ -44,8 +47,11 @@
                                 <input type="text" class="slds-input slds-combobox__input" id="combobox-unique-id"
                                     aria-activedescendant="listbox-option-unique-id-01" aria-autocomplete="list"
                                     aria-controls="listbox-unique-id" autocomplete="off" role="combobox"
-                                    placeholder="{!v.placeholder}" onkeyup="{!c.fetchSearchResults}"
+                                    placeholder="{!v.placeholder}"
+                                    onkeyup="{!c.fetchSearchResults}" onfocus="{!c.fetchSearchResults}"
+                                    value="{#v.searchText}"
                                 />
+                                <!-- onblur="{!c.hideSearchResults}" -->
                                 <aura:set attribute="else">
                                     <span class="slds-pill slds-pill_link fullWidth">
                                         <a href="javascript:void(0);" class="slds-pill__action slds-p-left_x-small" title="{#v.selectedRecord.displayText}">
@@ -61,7 +67,7 @@
                             </aura:if>
                        	</div>
                     </div>
-                    <aura:if isTrue="{!greaterthanorequal(v.searchResults.length, 1)}">
+                    <aura:if isTrue="{!and(v.showSearchResults, greaterthan(v.searchResults.length, 0))}">
                         <div id="listbox-unique-id" role="listbox">
                             <ul class="slds-listbox slds-listbox_vertical slds-dropdown slds-dropdown_fluid" role="presentation"
                                 style="display:block; min-width:auto; max-width:100%; width:100%;">

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -106,7 +106,7 @@
                                                     <span class="slds-assistive-text">{#v.parentSObjectMetadata.label}</span>
                                                 </span>
                                             </span>
-                                            <span class="slds-media__body singleRow">
+                                            <span class="slds-media__body">
                                                 <span class="slds-listbox__option-text slds-listbox__option-text_entity">{#matchingRecord.displayText}</span>
                                             </span>
                                         </span>

--- a/src/aura/lookup/lookup.cmp
+++ b/src/aura/lookup/lookup.cmp
@@ -98,7 +98,8 @@
                                     <li role="presentation" class="slds-listbox__item" data-selectedIndex="{#i}" onclick="{!c.itemSelected}">
                                         <span id="{# 'listbox-option-unique-id-' + i + 1}"
                                             class="slds-media slds-listbox__option slds-listbox__option_entity slds-listbox__option_has-meta"
-                                            role="option">
+                                            role="option"
+                                        >
                                             <span class="slds-media__figure optionIcon">
                                                 <span class="slds-icon_container" >
                                                     <lightning:icon iconName="{#v.parentSObjectMetadata.tabIcon}" size="small" />
@@ -106,7 +107,7 @@
                                                 </span>
                                             </span>
                                             <span class="slds-media__body singleRow">
-                                                <span class="optionTitle slds-listbox__option-text slds-listbox__option-text_entity">{#matchingRecord.displayText}</span>
+                                                <span class="slds-listbox__option-text slds-listbox__option-text_entity">{#matchingRecord.displayText}</span>
                                             </span>
                                         </span>
                                     </li>

--- a/src/aura/lookup/lookup.cmp-meta.xml
+++ b/src/aura/lookup/lookup.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <description>lookup</description>
+</AuraDefinitionBundle>

--- a/src/aura/lookup/lookup.css
+++ b/src/aura/lookup/lookup.css
@@ -1,0 +1,43 @@
+.THIS {
+    width: 99%;
+}
+.THIS .fullWidth {
+    width: 100%;
+}
+.THIS .slds-listbox__item:hover {
+    background: #d8edff;
+    text-shadow: none;
+    color: #16325c;
+}
+
+.THIS .optionParent1 {
+    line-height: 1.5;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.8125rem;
+}
+
+.THIS .optionIcon {
+   margin-top: 0.50rem;
+}
+
+.THIS .optionTitle {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+    margin-bottom: 0.125rem;
+}
+
+.THIS .optionline {
+    display: block;
+    margin-top: -0.25rem;
+    color: #54698d;
+}
+.THIS .singleRow {
+    padding-top: 5px;
+}
+
+.THIS .hide {
+    display: none;
+}

--- a/src/aura/lookup/lookup.css
+++ b/src/aura/lookup/lookup.css
@@ -1,5 +1,5 @@
 .THIS {
-    width: 99%;
+    width: 100%;
 }
 .THIS .slds-pill_link {
     margin: 4px;

--- a/src/aura/lookup/lookup.css
+++ b/src/aura/lookup/lookup.css
@@ -1,43 +1,7 @@
 .THIS {
     width: 99%;
 }
-.THIS .fullWidth {
-    width: 100%;
-}
-.THIS .slds-listbox__item:hover {
-    background: #d8edff;
-    text-shadow: none;
-    color: #16325c;
-}
-
-.THIS .optionParent1 {
-    line-height: 1.5;
-    padding: 0.25rem 0.75rem;
-    font-size: 0.8125rem;
-}
-
-.THIS .optionIcon {
-   margin-top: 0.50rem;
-}
-
-.THIS .optionTitle {
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: block;
-    margin-bottom: 0.125rem;
-}
-
-.THIS .optionline {
-    display: block;
-    margin-top: -0.25rem;
-    color: #54698d;
-}
-.THIS .singleRow {
-    padding-top: 5px;
-}
-
-.THIS .hide {
-    display: none;
+.THIS .slds-pill_link {
+    margin: 4px;
+    width: calc(100% - 8px);
 }

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -5,10 +5,25 @@
 
         if(!fieldMetadata) return;
 
-        var defaultParentSObjectName = fieldMetadata.relationshipReferences[0].name;
+        component.set('v.parentSObjectName', fieldMetadata.relationshipReferences[0].name);
+    },
+    toggleParentSObjectSelector : function(component, event, helper) {
+        console.log('lookup toggleSObjectSelector');
+        component.set('v.showSObjectSelector', !component.get('v.showSObjectSelector'));
+        component.set('v.showSearchResults', !component.get('v.showSearchResults'));
+    },
+    selectParentSObject : function(component, event, helper) {
+        console.log('lookup selectParentSObject');
+        var parentSObjectName = event.currentTarget.dataset.sobjectname;
+        console.log('parentSObjectName=' + parentSObjectName);
+        component.set('v.parentSObjectName', parentSObjectName);
+        component.set('v.showSObjectSelector', false);
+    },
+    fetchParentSObjectMetadata :  function(component, event, helper) {
+        var parentSObjectName = component.get('v.parentSObjectName');
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
-        sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);
+        sobjectMetadataService.set('v.sobjectName', parentSObjectName);
         sobjectMetadataService.fetch(function(error, data) {
             component.set('v.parentSObjectMetadata', data);
         });

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -5,10 +5,11 @@
 
         if(!fieldMetadata) return;
 
-        var parentSObjectName = fieldMetadata.relationshipReferences[0];
+        var defaultParentSObjectName = fieldMetadata.relationshipReferences[0];
+        console.log('defaultParentSObjectName=' + defaultParentSObjectName);
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
-        sobjectMetadataService.set('v.sobjectName', parentSObjectName);
+        sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);
         sobjectMetadataService.fetch(function(error, data) {
             component.set('v.parentSObjectMetadata', data);
         });

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -6,81 +6,17 @@
         if(!fieldMetadata) return;
 
         var parentSObjectName = fieldMetadata.relationshipReferences[0];
-        //if(!component.get('v.parentSObjectMetadata')) return;
-        /*$A.createComponent(
-            "sobjectMetadata",
-            {
-                "aura:id": "parentSObjectMetadataCmp",
-                "sobjectName": parentSObjectName
-            },
-            function(newSObjectMetadataCmp, status, errorMessage){
-                //Add the new button to the body array
-                if (status === "SUCCESS") {
-                    var body = component.get("v.body");
-                    body.push(newSObjectMetadataCmp);
-                    component.set("v.body", body);
-                    console.log('added sobjectMetadataCmp');
-                    console.log(component.get('v.body'));
-                    console.log(component.get('v.body').find('parentSObjectMetadataCmp'));
-                }
-                else if (status === "INCOMPLETE") {
-                    console.log("No response from server or client is offline.")
-                    // Show offline error
-                }
-                else if (status === "ERROR") {
-                    console.log("Error: " + errorMessage);
-                    // Show error message
-                }
-            }
-        );*/
 
-var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
-
-if(!parentSObjectMetadataComponent || !parentSObjectMetadataComponent.get('v.sobjectMetadata')) return;
-
-var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
-
-console.log('parentSObjectMetadata');
-console.log(parentSObjectMetadata);
-console.log('done parentSObjectMetadata');
-component.set('v.parentSObjectMetadata', parentSObjectMetadata);
-console.log('parentSObjectMetadata');
-console.log(parentSObjectMetadata);
-component.find('parentSObjectMetadataCmp').set('v.parentSObjectName', parentSObjectName);
-/*component.set('v.parentSObjectName', parentSObjectMetadata.name);
-component.set('v.displayTextFieldName', parentSObjectMetadata.nameField);
-component.set('v.searchFieldName', parentSObjectMetadata.nameField);*/
-
-
+        var sobjectMetadataService = component.find('sobjectMetadataService');
+        sobjectMetadataService.set('v.sobjectName', parentSObjectName);
+        sobjectMetadataService.fetch(function(error, data) {
+            component.set('v.parentSObjectMetadata', data);
+        });
     },
     fetchSearchResults :  function(component, event, helper) {
         console.log('fetchSearchResults');
-        var fieldMetadata = component.get('v.fieldMetadata');
-
-        if(!fieldMetadata) return;
-
-        var parentSObjectName = fieldMetadata.relationshipReferences[0];
-
-        var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
-        if(!parentSObjectMetadata) {
-            var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
-
-            if(!parentSObjectMetadataComponent || !parentSObjectMetadataComponent.get('v.sobjectMetadata')) return;
-
-            var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
-
-            console.log('parentSObjectMetadata');
-            console.log(parentSObjectMetadata);
-            console.log('done parentSObjectMetadata');
-            component.set('v.parentSObjectMetadata', parentSObjectMetadata);
-            console.log('parentSObjectMetadata');
-            console.log(parentSObjectMetadata);
-            component.find('parentSObjectMetadataCmp').set('v.sobjectName', parentSObjectName);
-        }
-
-
-        component.set('v.showSearchResults', true);
         helper.fetchSearchResults(component, event, helper);
+        component.set('v.showSearchResults', true);
     },
     hideSearchResults : function(component, event, helper) {
         console.log('hideSearchResults');

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -5,8 +5,7 @@
 
         if(!fieldMetadata) return;
 
-        var relationshipReferences = fieldMetadata.relationshipReferences;
-        var defaultParentSObjectName = relationshipReferences[Object.keys(relationshipReferences)[0]].name;
+        var defaultParentSObjectName = fieldMetadata.relationshipReferences[0].name;
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
         sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -1,5 +1,12 @@
 ({
     doInit :  function(component, event, helper) {
+        var record = component.get('v.record');
+        var fieldName = component.get('v.fieldName');
+        if(record.hasOwnProperty(fieldName)) {
+            component.set('v.selectedParentRecordId', record[fieldName]);
+        }
+    },
+    parseFieldMetadata :  function(component, event, helper) {
         var fieldMetadata = component.get('v.fieldMetadata');
 
         if(!fieldMetadata) return;
@@ -39,6 +46,19 @@
             break;
         }
         component.set('v.parentSObjectMetadata', selectedSObjectMetadata);
+    },
+    loadSelectedParentRecord :  function(component, event, helper) {
+        var selectedParentRecordId = component.get('v.selectedParentRecordId');
+        var selectedParentRecord   = component.get('v.selectedParentRecord');
+
+        // If no record ID, then there's nothing to load
+        if(selectedParentRecordId === null) return;
+
+        // If we already have the parent record loaded, don't query again
+        if(selectedParentRecord !== null && selectedParentRecordId === selectedParentRecord.Id) return;
+
+        // Query for the parent record
+        helper.fetchSelectedParentRecord(component, event, helper);
     },
     fetchSearchResults :  function(component, event, helper) {
         helper.fetchSearchResults(component, event, helper);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -1,6 +1,84 @@
 ({
+    doInit :  function(component, event, helper) {
+        console.log('lookup doInit');
+        var fieldMetadata = component.get('v.fieldMetadata');
+
+        if(!fieldMetadata) return;
+
+        var parentSObjectName = fieldMetadata.relationshipReferences[0];
+        //if(!component.get('v.parentSObjectMetadata')) return;
+        /*$A.createComponent(
+            "sobjectMetadata",
+            {
+                "aura:id": "parentSObjectMetadataCmp",
+                "sobjectName": parentSObjectName
+            },
+            function(newSObjectMetadataCmp, status, errorMessage){
+                //Add the new button to the body array
+                if (status === "SUCCESS") {
+                    var body = component.get("v.body");
+                    body.push(newSObjectMetadataCmp);
+                    component.set("v.body", body);
+                    console.log('added sobjectMetadataCmp');
+                    console.log(component.get('v.body'));
+                    console.log(component.get('v.body').find('parentSObjectMetadataCmp'));
+                }
+                else if (status === "INCOMPLETE") {
+                    console.log("No response from server or client is offline.")
+                    // Show offline error
+                }
+                else if (status === "ERROR") {
+                    console.log("Error: " + errorMessage);
+                    // Show error message
+                }
+            }
+        );*/
+
+var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
+
+if(!parentSObjectMetadataComponent || !parentSObjectMetadataComponent.get('v.sobjectMetadata')) return;
+
+var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
+
+console.log('parentSObjectMetadata');
+console.log(parentSObjectMetadata);
+console.log('done parentSObjectMetadata');
+component.set('v.parentSObjectMetadata', parentSObjectMetadata);
+console.log('parentSObjectMetadata');
+console.log(parentSObjectMetadata);
+component.find('parentSObjectMetadataCmp').set('v.parentSObjectName', parentSObjectName);
+/*component.set('v.parentSObjectName', parentSObjectMetadata.name);
+component.set('v.displayTextFieldName', parentSObjectMetadata.nameField);
+component.set('v.searchFieldName', parentSObjectMetadata.nameField);*/
+
+
+    },
     fetchSearchResults :  function(component, event, helper) {
         console.log('fetchSearchResults');
+        var fieldMetadata = component.get('v.fieldMetadata');
+
+        if(!fieldMetadata) return;
+
+        var parentSObjectName = fieldMetadata.relationshipReferences[0];
+
+        var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
+        if(!parentSObjectMetadata) {
+            var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
+
+            if(!parentSObjectMetadataComponent || !parentSObjectMetadataComponent.get('v.sobjectMetadata')) return;
+
+            var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
+
+            console.log('parentSObjectMetadata');
+            console.log(parentSObjectMetadata);
+            console.log('done parentSObjectMetadata');
+            component.set('v.parentSObjectMetadata', parentSObjectMetadata);
+            console.log('parentSObjectMetadata');
+            console.log(parentSObjectMetadata);
+            component.find('parentSObjectMetadataCmp').set('v.sobjectName', parentSObjectName);
+        }
+
+
         component.set('v.showSearchResults', true);
         helper.fetchSearchResults(component, event, helper);
     },

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -1,0 +1,11 @@
+({
+    fetchSearchResults :  function(component, event, helper) {
+        helper.fetchSearchResults(component, event, helper);
+    },
+    itemSelected : function(component, event, helper) {
+        helper.itemSelected(component, event, helper);
+    },
+    clearSelection : function(component, event, helper){
+        helper.clearSelection(component, event, helper);
+    }
+})

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -5,7 +5,7 @@
     itemSelected : function(component, event, helper) {
         helper.itemSelected(component, event, helper);
     },
-    clearSelection : function(component, event, helper){
+    clearSelection : function(component, event, helper) {
         helper.clearSelection(component, event, helper);
     }
 })

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -1,49 +1,56 @@
 ({
     doInit :  function(component, event, helper) {
-        console.log('lookup doInit');
         var fieldMetadata = component.get('v.fieldMetadata');
 
         if(!fieldMetadata) return;
 
-        component.set('v.parentSObjectName', fieldMetadata.relationshipReferences[0].name);
+        var defaultRelationshipReference;
+        for(var i = 0; i < fieldMetadata.relationshipReferences.length; i++) {
+            var relationshipReference = fieldMetadata.relationshipReferences[i];
+            if(relationshipReference.isAccessible === true) {
+                defaultRelationshipReference = relationshipReference;
+                break;
+            }
+        }
+        component.set('v.parentSObjectName', defaultRelationshipReference.name);
     },
     toggleParentSObjectSelector : function(component, event, helper) {
-        console.log('lookup toggleSObjectSelector');
         component.set('v.showSObjectSelector', !component.get('v.showSObjectSelector'));
         component.set('v.showSearchResults', !component.get('v.showSearchResults'));
     },
     selectParentSObject : function(component, event, helper) {
-        console.log('lookup selectParentSObject');
         var parentSObjectName = event.currentTarget.dataset.sobjectname;
-        console.log('parentSObjectName=' + parentSObjectName);
-        component.set('v.parentSObjectMetadata', null);
         component.set('v.parentSObjectName', parentSObjectName);
-        component.set('v.showSObjectSelector', false);
     },
-    fetchParentSObjectMetadata :  function(component, event, helper) {
+    loadParentSObjectMetadata : function(component, event, helper) {
+        component.set('v.showSearchResults', null);
+        component.set('v.showSObjectSelector', false);
+
+        var fieldMetadata = component.get('v.fieldMetadata');
         var parentSObjectName = component.get('v.parentSObjectName');
 
-        var sobjectMetadataService = component.find('sobjectMetadataService');
-        sobjectMetadataService.set('v.sobjectName', parentSObjectName);
-        sobjectMetadataService.fetch(function(error, data) {
-            component.set('v.parentSObjectMetadata', data);
-        });
+        var selectedSObjectMetadata;
+        for(var i = 0; i < fieldMetadata.relationshipReferences.length; i++) {
+            var relationshipReference = fieldMetadata.relationshipReferences[i];
+
+            if(relationshipReference.name !== parentSObjectName) continue;
+
+            selectedSObjectMetadata = fieldMetadata.relationshipReferences[i];
+            break;
+        }
+        component.set('v.parentSObjectMetadata', selectedSObjectMetadata);
     },
     fetchSearchResults :  function(component, event, helper) {
-        console.log('fetchSearchResults');
         helper.fetchSearchResults(component, event, helper);
         component.set('v.showSearchResults', true);
     },
     hideSearchResults : function(component, event, helper) {
-        console.log('hideSearchResults');
         component.set('v.showSearchResults', false);
     },
     itemSelected : function(component, event, helper) {
-        console.log('itemSelected');
         helper.itemSelected(component, event, helper);
     },
     clearSelection : function(component, event, helper) {
-        console.log('clearSelection');
         helper.clearSelection(component, event, helper);
     }
 })

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -67,8 +67,8 @@
     hideSearchResults : function(component, event, helper) {
         component.set('v.showSearchResults', false);
     },
-    itemSelected : function(component, event, helper) {
-        helper.itemSelected(component, event, helper);
+    parentRecordSelected : function(component, event, helper) {
+        helper.parentRecordSelected(component, event, helper);
     },
     clearSelection : function(component, event, helper) {
         helper.clearSelection(component, event, helper);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -21,10 +21,10 @@
     selectParentSObject : function(component, event, helper) {
         var parentSObjectName = event.currentTarget.dataset.sobjectname;
         component.set('v.parentSObjectName', parentSObjectName);
+        component.set('v.showSObjectSelector', false);
     },
     loadParentSObjectMetadata : function(component, event, helper) {
         component.set('v.searchResults', null);
-        component.set('v.showSObjectSelector', false);
 
         var fieldMetadata = component.get('v.fieldMetadata');
         var parentSObjectName = component.get('v.parentSObjectName');

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -1,11 +1,19 @@
 ({
     fetchSearchResults :  function(component, event, helper) {
+        console.log('fetchSearchResults');
+        component.set('v.showSearchResults', true);
         helper.fetchSearchResults(component, event, helper);
     },
+    hideSearchResults : function(component, event, helper) {
+        console.log('hideSearchResults');
+        component.set('v.showSearchResults', false);
+    },
     itemSelected : function(component, event, helper) {
+        console.log('itemSelected');
         helper.itemSelected(component, event, helper);
     },
     clearSelection : function(component, event, helper) {
+        console.log('clearSelection');
         helper.clearSelection(component, event, helper);
     }
 })

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -5,7 +5,8 @@
 
         if(!fieldMetadata) return;
 
-        var defaultParentSObjectName = fieldMetadata.relationshipReferences[0];
+        var relationshipReferences = fieldMetadata.relationshipReferences;
+        var defaultParentSObjectName = relationshipReferences[Object.keys(relationshipReferences)[1]].name;
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
         sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -6,7 +6,7 @@
         if(!fieldMetadata) return;
 
         var relationshipReferences = fieldMetadata.relationshipReferences;
-        var defaultParentSObjectName = relationshipReferences[Object.keys(relationshipReferences)[1]].name;
+        var defaultParentSObjectName = relationshipReferences[Object.keys(relationshipReferences)[0]].name;
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
         sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -6,7 +6,6 @@
         if(!fieldMetadata) return;
 
         var defaultParentSObjectName = fieldMetadata.relationshipReferences[0];
-        console.log('defaultParentSObjectName=' + defaultParentSObjectName);
 
         var sobjectMetadataService = component.find('sobjectMetadataService');
         sobjectMetadataService.set('v.sobjectName', defaultParentSObjectName);

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -23,7 +23,7 @@
         component.set('v.parentSObjectName', parentSObjectName);
     },
     loadParentSObjectMetadata : function(component, event, helper) {
-        component.set('v.showSearchResults', null);
+        component.set('v.searchResults', null);
         component.set('v.showSObjectSelector', false);
 
         var fieldMetadata = component.get('v.fieldMetadata');

--- a/src/aura/lookup/lookupController.js
+++ b/src/aura/lookup/lookupController.js
@@ -16,6 +16,7 @@
         console.log('lookup selectParentSObject');
         var parentSObjectName = event.currentTarget.dataset.sobjectname;
         console.log('parentSObjectName=' + parentSObjectName);
+        component.set('v.parentSObjectMetadata', null);
         component.set('v.parentSObjectName', parentSObjectName);
         component.set('v.showSObjectSelector', false);
     },

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -1,4 +1,17 @@
 ({
+    fetchSelectedParentRecord : function(component, event, helper) {
+        var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
+        var action = component.get('c.getRecord');
+        action.setParams({
+            recordId : component.get('v.selectedParentRecordId')
+        });
+        action.setStorable();
+        action.setCallback(this, function(response) {
+            component.set('v.selectedParentRecord', response.getReturnValue());
+            component.set('v.parentSObjectName', response.getReturnValue().sobjectName);
+        });
+        $A.enqueueAction(action);
+    },
     fetchSearchResults : function(component, event, helper) {
         var searchText = event && event.target ? event.target.value : null;
 
@@ -43,7 +56,7 @@
     },
     handleResponse : function (response,component,helper) {
         if(response.getState() === 'SUCCESS') {
-            var searchResults = JSON.parse(response.getReturnValue());
+            var searchResults = response.getReturnValue();
             if(searchResults.length === 0) {
                 component.set('v.searchResults', null);
             } else {

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -5,19 +5,12 @@
         var fieldMetadata = component.get('v.fieldMetadata');
         var parentSObjectName = fieldMetadata.relationshipReferences[0];
 
-        //Escape button pressed
-        if(event.keyCode == 27) {
+        // Escape button pressed
+        var escapeKeyCode = 27;
+        if(event.keyCode == escapeKeyCode) {
             helper.clearSelection(component, event, helper);
         } else {
-            /*var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
-
-            if(!parentSObjectMetadata) return;*/
-var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
-parentSObjectMetadataComponent.set('v.sobjectName', parentSObjectName);
-
-//var parentSObjectMetadata =  component.find('parentSObjectMetadataCmp').get('v.sobjectMetadata');
-//var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
-var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
+            var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
             var action = component.get('c.search');
             action.setParams({
                 parentSObjectName    : parentSObjectMetadata.name,
@@ -42,8 +35,7 @@ var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadat
             var childRecord = component.get('v.childRecord');
             var childRecordLookupFieldName = component.get('v.childRecordLookupFieldName');
             var selectedRecord = serverResult[selectedRecordIndex];
-            console.log('selectedRecord');
-            console.log(selectedRecord);
+
             if(selectedRecord.record) {
                 childRecord[childRecordLookupFieldName] = selectedRecord.record.Id;
                 component.set('v.selectedRecord', selectedRecord);

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -26,12 +26,12 @@
         var selectedRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
         if(selectedRecordIndex) {
             var searchResults = component.get('v.searchResults');
-            var childRecord = component.get('v.childRecord');
+            var record = component.get('v.record');
             var fieldName = component.get('v.fieldName');
             var selectedRecord = searchResults[selectedRecordIndex];
 
             if(selectedRecord.record) {
-                childRecord[fieldName] = selectedRecord.record.Id;
+                record[fieldName] = selectedRecord.record.Id;
                 component.set('v.selectedRecord', selectedRecord);
             }
             component.set('v.searchResults', null);

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -1,0 +1,89 @@
+({
+    fetchSearchResults : function(component, event, helper) {
+        var target = event.target;
+        var searchText = target.value;
+        var last_SearchText = component.get('v.last_SearchText');
+        //Escape button pressed
+        if(event.keyCode == 27 || !searchText.trim()) {
+            helper.clearSelection(component, event, helper);
+        } else if(searchText.trim() != last_SearchText  && /\s+$/.test(searchText)) {
+            //Save server call, if last text not changed
+            //Search only when space character entered
+
+            var sobjectName = component.get('v.sobjectName');
+            var field_API_text = component.get('v.field_API_text');
+            var fieldName = component.get('v.fieldName');
+            var field_API_search = component.get('v.field_API_search');
+            var limit = component.get('v.limit');
+
+            var action = component.get('c.search');
+            action.setStorable();
+
+            action.setParams({
+                sobjectName : sobjectName,
+                fld_API_Text : field_API_text,
+                fld_API_Val : fieldName,
+                limitCount : limit,
+                fld_API_Search : field_API_search,
+                searchText : searchText
+            });
+
+            action.setCallback(this,function(a) {
+                this.handleResponse(a,component,helper);
+            });
+
+            component.set('v.last_SearchText',searchText.trim());
+            console.log('Server call made');
+            $A.enqueueAction(action);
+        } else if(searchText && last_SearchText && searchText.trim() == last_SearchText.trim()) {
+            component.set('v.searchResults', component.get('v.last_ServerResult'));
+            console.log('Server call saved');
+        }
+    },
+    itemSelected : function(component, event, helper) {
+        var target = event.target;
+        var selectedRecordIndex = helper.getIndexFrmParent(target, helper, 'data-selectedIndex');
+        if(selectedRecordIndex) {
+            var serverResult = component.get('v.searchResults');
+            var selectedRecord = serverResult[selectedRecordIndex];
+            console.log('selectedRecord');
+            console.log(selectedRecord);
+            if(selectedRecord.recordId) {
+               component.set('v.selectedRecord', selectedRecord);
+               component.set('v.last_ServerResult', serverResult);
+            }
+            component.set('v.searchResults', null);
+        }
+    },
+    clearSelection: function(component, event, helper) {
+        component.set('v.selectedRecord', null);
+        component.set('v.searchResults', null);
+    },
+    handleResponse : function (res,component,helper) {
+        if(res.getState() === 'SUCCESS') {
+            var retObj = JSON.parse(res.getReturnValue());
+            if(retObj.length <= 0) {
+                var noResult = JSON.parse('[{"text":"No Results Found"}]');
+                component.set('v.searchResults', noResult);
+                component.set('v.last_ServerResult', noResult);
+            } else {
+                component.set('v.searchResults', retObj);
+                component.set('v.last_ServerResult', retObj);
+            }
+        }else if(res.getState() === 'ERROR') {
+            var errors = res.getError();
+            if(errors && errors[0] && errors[0].message) {
+                alert(errors[0].message);
+            }
+        }
+    },
+    getIndexFrmParent : function(target, helper, attributeToFind) {
+        //User can click on any child element, so traverse till intended parent found
+        var selectedRecordIndex = target.getAttribute(attributeToFind);
+        while(!selectedRecordIndex) {
+            target = target.parentNode;
+            selectedRecordIndex = helper.getIndexFrmParent(target, helper, attributeToFind);
+        }
+        return selectedRecordIndex;
+    }
+})

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -11,21 +11,20 @@
             //Search only when space character entered
 
             var sobjectName = component.get('v.sobjectName');
-            var field_API_text = component.get('v.field_API_text');
-            var fieldName = component.get('v.fieldName');
-            var field_API_search = component.get('v.field_API_search');
+            var displayTextFieldName = component.get('v.displayTextFieldName');
+            //var fieldName = component.get('v.fieldName');
+            var searchFieldName = component.get('v.searchFieldName');
             var limit = component.get('v.limit');
 
             var action = component.get('c.search');
             action.setStorable();
 
             action.setParams({
-                sobjectName : sobjectName,
-                fld_API_Text : field_API_text,
-                fld_API_Val : fieldName,
-                limitCount : limit,
-                fld_API_Search : field_API_search,
-                searchText : searchText
+                sobjectName          : sobjectName,
+                searchFieldName      : searchFieldName,
+                searchText           : searchText,
+                displayTextFieldName : displayTextFieldName,
+                limitCount           : limit
             });
 
             action.setCallback(this,function(a) {

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -1,16 +1,29 @@
 ({
     fetchSearchResults : function(component, event, helper) {
         var searchText = event && event.target ? event.target.value : null;
+
+        var fieldMetadata = component.get('v.fieldMetadata');
+        var parentSObjectName = fieldMetadata.relationshipReferences[0];
+
         //Escape button pressed
         if(event.keyCode == 27) {
             helper.clearSelection(component, event, helper);
         } else {
+            /*var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
+
+            if(!parentSObjectMetadata) return;*/
+var parentSObjectMetadataComponent = component.find('parentSObjectMetadataCmp');
+parentSObjectMetadataComponent.set('v.sobjectName', parentSObjectName);
+
+//var parentSObjectMetadata =  component.find('parentSObjectMetadataCmp').get('v.sobjectMetadata');
+//var parentSObjectMetadata = component.get('v.parentSObjectMetadata');
+var parentSObjectMetadata = parentSObjectMetadataComponent.get('v.sobjectMetadata');
             var action = component.get('c.search');
             action.setParams({
-                parentSObjectName    : component.get('v.parentSObjectName'),
-                searchFieldName      : component.get('v.searchFieldName'),
+                parentSObjectName    : parentSObjectMetadata.name,
+                searchFieldName      : parentSObjectMetadata.nameField,
                 searchText           : searchText,
-                displayTextFieldName : component.get('v.displayTextFieldName'),
+                displayTextFieldName : parentSObjectMetadata.nameField,
                 limitCount           : component.get('v.limitCount')
             });
             action.setStorable();

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -25,13 +25,13 @@
     itemSelected : function(component, event, helper) {
         var selectedRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
         if(selectedRecordIndex) {
-            var serverResult = component.get('v.searchResults');
+            var searchResults = component.get('v.searchResults');
             var childRecord = component.get('v.childRecord');
-            var childRecordLookupFieldName = component.get('v.childRecordLookupFieldName');
-            var selectedRecord = serverResult[selectedRecordIndex];
+            var fieldName = component.get('v.fieldName');
+            var selectedRecord = searchResults[selectedRecordIndex];
 
             if(selectedRecord.record) {
-                childRecord[childRecordLookupFieldName] = selectedRecord.record.Id;
+                childRecord[fieldName] = selectedRecord.record.Id;
                 component.set('v.selectedRecord', selectedRecord);
             }
             component.set('v.searchResults', null);

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -23,8 +23,6 @@
             action.setCallback(this, function(response) {
                 this.handleResponse(response, component, helper);
             });
-
-            console.log('Server call made');
             $A.enqueueAction(action);
         }
     },

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -2,10 +2,6 @@
     fetchSearchResults : function(component, event, helper) {
         var searchText = event && event.target ? event.target.value : null;
 
-        var fieldMetadata = component.get('v.fieldMetadata');
-        var parentSObjectName = fieldMetadata.relationshipReferences[0];
-
-        // Escape button pressed
         var escapeKeyCode = 27;
         if(event.keyCode == escapeKeyCode) {
             helper.clearSelection(component, event, helper);
@@ -47,11 +43,11 @@
     },
     handleResponse : function (response,component,helper) {
         if(response.getState() === 'SUCCESS') {
-            var retObj = JSON.parse(response.getReturnValue());
-            if(retObj.length <= 0) {
+            var searchResults = JSON.parse(response.getReturnValue());
+            if(searchResults.length === 0) {
                 component.set('v.searchResults', null);
             } else {
-                component.set('v.searchResults', retObj);
+                component.set('v.searchResults', searchResults);
             }
         } else if(response.getState() === 'ERROR') {
             var errors = response.getError();
@@ -61,7 +57,7 @@
         }
     },
     getIndexFrmParent : function(target, helper, attributeToFind) {
-        //User can click on any child element, so traverse till intended parent found
+        // User can click on any child element, so traverse till intended parent found
         var selectedRecordIndex = target.getAttribute(attributeToFind);
         while(!selectedRecordIndex) {
             target = target.parentNode;

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -7,8 +7,15 @@
         });
         action.setStorable();
         action.setCallback(this, function(response) {
-            component.set('v.selectedParentRecord', response.getReturnValue());
-            component.set('v.parentSObjectName', response.getReturnValue().sobjectName);
+            if(response.getState() === 'SUCCESS') {
+                component.set('v.selectedParentRecord', response.getReturnValue());
+                component.set('v.parentSObjectName', response.getReturnValue().sobjectName);
+            } else if(response.getState() === 'ERROR') {
+                var errors = response.getError();
+                if(errors && errors[0] && errors[0].message) {
+                    alert(errors[0].message);
+                }
+            }
         });
         $A.enqueueAction(action);
     },
@@ -30,12 +37,19 @@
             });
             action.setStorable();
             action.setCallback(this, function(response) {
-                this.handleResponse(response, component, helper);
+                if(response.getState() === 'SUCCESS') {
+                    component.set('v.searchResults', response.getReturnValue());
+                } else if(response.getState() === 'ERROR') {
+                    var errors = response.getError();
+                    if(errors && errors[0] && errors[0].message) {
+                        alert(errors[0].message);
+                    }
+                }
             });
             $A.enqueueAction(action);
         }
     },
-    itemSelected : function(component, event, helper) {
+    parentRecordSelected : function(component, event, helper) {
         var selectedParentRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
         if(selectedParentRecordIndex) {
             var searchResults = component.get('v.searchResults');
@@ -53,21 +67,6 @@
     clearSelection: function(component, event, helper) {
         component.set('v.selectedParentRecord', null);
         component.set('v.searchResults', null);
-    },
-    handleResponse : function (response,component,helper) {
-        if(response.getState() === 'SUCCESS') {
-            var searchResults = response.getReturnValue();
-            if(searchResults.length === 0) {
-                component.set('v.searchResults', null);
-            } else {
-                component.set('v.searchResults', searchResults);
-            }
-        } else if(response.getState() === 'ERROR') {
-            var errors = response.getError();
-            if(errors && errors[0] && errors[0].message) {
-                alert(errors[0].message);
-            }
-        }
     },
     getIndexFrmParent : function(target, helper, attributeToFind) {
         // User can click on any child element, so traverse till intended parent found

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -23,22 +23,22 @@
         }
     },
     itemSelected : function(component, event, helper) {
-        var selectedRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
-        if(selectedRecordIndex) {
+        var selectedParentRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
+        if(selectedParentRecordIndex) {
             var searchResults = component.get('v.searchResults');
             var record = component.get('v.record');
             var fieldName = component.get('v.fieldName');
-            var selectedRecord = searchResults[selectedRecordIndex];
+            var selectedParentRecord = searchResults[selectedParentRecordIndex];
 
-            if(selectedRecord.record) {
-                record[fieldName] = selectedRecord.record.Id;
-                component.set('v.selectedRecord', selectedRecord);
+            if(selectedParentRecord.record) {
+                record[fieldName] = selectedParentRecord.record.Id;
+                component.set('v.selectedParentRecord', selectedParentRecord);
             }
             component.set('v.searchResults', null);
         }
     },
     clearSelection: function(component, event, helper) {
-        component.set('v.selectedRecord', null);
+        component.set('v.selectedParentRecord', null);
         component.set('v.searchResults', null);
     },
     handleResponse : function (response,component,helper) {
@@ -58,11 +58,11 @@
     },
     getIndexFrmParent : function(target, helper, attributeToFind) {
         // User can click on any child element, so traverse till intended parent found
-        var selectedRecordIndex = target.getAttribute(attributeToFind);
-        while(!selectedRecordIndex) {
+        var selectedParentRecordIndex = target.getAttribute(attributeToFind);
+        while(!selectedParentRecordIndex) {
             target = target.parentNode;
-            selectedRecordIndex = helper.getIndexFrmParent(target, helper, attributeToFind);
+            selectedParentRecordIndex = helper.getIndexFrmParent(target, helper, attributeToFind);
         }
-        return selectedRecordIndex;
+        return selectedParentRecordIndex;
     }
 })

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -50,7 +50,7 @@
         }
     },
     parentRecordSelected : function(component, event, helper) {
-        var selectedParentRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
+        var selectedParentRecordIndex = helper.getIndexFromParent(event.target, helper, 'data-selectedparentindex');
         if(selectedParentRecordIndex) {
             var searchResults = component.get('v.searchResults');
             var record = component.get('v.record');
@@ -68,12 +68,11 @@
         component.set('v.selectedParentRecord', null);
         component.set('v.searchResults', null);
     },
-    getIndexFrmParent : function(target, helper, attributeToFind) {
-        // User can click on any child element, so traverse till intended parent found
+    getIndexFromParent : function(target, helper, attributeToFind) {
         var selectedParentRecordIndex = target.getAttribute(attributeToFind);
         while(!selectedParentRecordIndex) {
             target = target.parentNode;
-            selectedParentRecordIndex = helper.getIndexFrmParent(target, helper, attributeToFind);
+            selectedParentRecordIndex = helper.getIndexFromParent(target, helper, attributeToFind);
         }
         return selectedParentRecordIndex;
     }

--- a/src/aura/lookup/lookupHelper.js
+++ b/src/aura/lookup/lookupHelper.js
@@ -1,55 +1,39 @@
 ({
     fetchSearchResults : function(component, event, helper) {
-        var target = event.target;
-        var searchText = target.value;
-        var last_SearchText = component.get('v.last_SearchText');
+        var searchText = event && event.target ? event.target.value : null;
         //Escape button pressed
-        if(event.keyCode == 27 || !searchText.trim()) {
+        if(event.keyCode == 27) {
             helper.clearSelection(component, event, helper);
-        } else if(searchText.trim() != last_SearchText  && /\s+$/.test(searchText)) {
-            //Save server call, if last text not changed
-            //Search only when space character entered
-
-            var sobjectName = component.get('v.sobjectName');
-            var displayTextFieldName = component.get('v.displayTextFieldName');
-            //var fieldName = component.get('v.fieldName');
-            var searchFieldName = component.get('v.searchFieldName');
-            var limit = component.get('v.limit');
-
+        } else {
             var action = component.get('c.search');
-            action.setStorable();
-
             action.setParams({
-                sobjectName          : sobjectName,
-                searchFieldName      : searchFieldName,
+                parentSObjectName    : component.get('v.parentSObjectName'),
+                searchFieldName      : component.get('v.searchFieldName'),
                 searchText           : searchText,
-                displayTextFieldName : displayTextFieldName,
-                limitCount           : limit
+                displayTextFieldName : component.get('v.displayTextFieldName'),
+                limitCount           : component.get('v.limitCount')
+            });
+            action.setStorable();
+            action.setCallback(this, function(response) {
+                this.handleResponse(response, component, helper);
             });
 
-            action.setCallback(this,function(a) {
-                this.handleResponse(a,component,helper);
-            });
-
-            component.set('v.last_SearchText',searchText.trim());
             console.log('Server call made');
             $A.enqueueAction(action);
-        } else if(searchText && last_SearchText && searchText.trim() == last_SearchText.trim()) {
-            component.set('v.searchResults', component.get('v.last_ServerResult'));
-            console.log('Server call saved');
         }
     },
     itemSelected : function(component, event, helper) {
-        var target = event.target;
-        var selectedRecordIndex = helper.getIndexFrmParent(target, helper, 'data-selectedIndex');
+        var selectedRecordIndex = helper.getIndexFrmParent(event.target, helper, 'data-selectedIndex');
         if(selectedRecordIndex) {
             var serverResult = component.get('v.searchResults');
+            var childRecord = component.get('v.childRecord');
+            var childRecordLookupFieldName = component.get('v.childRecordLookupFieldName');
             var selectedRecord = serverResult[selectedRecordIndex];
             console.log('selectedRecord');
             console.log(selectedRecord);
-            if(selectedRecord.recordId) {
-               component.set('v.selectedRecord', selectedRecord);
-               component.set('v.last_ServerResult', serverResult);
+            if(selectedRecord.record) {
+                childRecord[childRecordLookupFieldName] = selectedRecord.record.Id;
+                component.set('v.selectedRecord', selectedRecord);
             }
             component.set('v.searchResults', null);
         }
@@ -58,19 +42,16 @@
         component.set('v.selectedRecord', null);
         component.set('v.searchResults', null);
     },
-    handleResponse : function (res,component,helper) {
-        if(res.getState() === 'SUCCESS') {
-            var retObj = JSON.parse(res.getReturnValue());
+    handleResponse : function (response,component,helper) {
+        if(response.getState() === 'SUCCESS') {
+            var retObj = JSON.parse(response.getReturnValue());
             if(retObj.length <= 0) {
-                var noResult = JSON.parse('[{"text":"No Results Found"}]');
-                component.set('v.searchResults', noResult);
-                component.set('v.last_ServerResult', noResult);
+                component.set('v.searchResults', null);
             } else {
                 component.set('v.searchResults', retObj);
-                component.set('v.last_ServerResult', retObj);
             }
-        }else if(res.getState() === 'ERROR') {
-            var errors = res.getError();
+        } else if(response.getState() === 'ERROR') {
+            var errors = response.getError();
             if(errors && errors[0] && errors[0].message) {
                 alert(errors[0].message);
             }

--- a/src/aura/outputField/outputFieldHelper.js
+++ b/src/aura/outputField/outputFieldHelper.js
@@ -9,7 +9,7 @@
         // Parent record name (used for REFERENCE fields)
         var relationshipName = fieldMetadata.relationshipName;
         var relationshipReferences = fieldMetadata.relationshipReferences;
-        var relationshipNameField = relationshipReferences[0].nameField;
+        var relationshipNameField = relationshipReferences && relationshipReferences.length > 0 ? relationshipReferences[0].nameField : null;
 
         if(record && record.hasOwnProperty(relationshipName)) {
             var parentRecord = record[relationshipName];

--- a/src/aura/outputField/outputFieldHelper.js
+++ b/src/aura/outputField/outputFieldHelper.js
@@ -9,7 +9,7 @@
         // Parent record name (used for REFERENCE fields)
         var relationshipName = fieldMetadata.relationshipName;// + '.' + fieldMetadata.relationshipNameField;
         var relationshipReferences = fieldMetadata.relationshipReferences;
-        var relationshipNameField = relationshipReferences[Object.keys(relationshipReferences)[0]].name;
+        var relationshipNameField = relationshipReferences[0].nameField;
 
         if(record && record.hasOwnProperty(relationshipName)) {
             var parentRecord = record[relationshipName];

--- a/src/aura/outputField/outputFieldHelper.js
+++ b/src/aura/outputField/outputFieldHelper.js
@@ -7,7 +7,7 @@
         component.set('v.displayType', fieldMetadata.displayType);
 
         // Parent record name (used for REFERENCE fields)
-        var relationshipName = fieldMetadata.relationshipName;// + '.' + fieldMetadata.relationshipNameField;
+        var relationshipName = fieldMetadata.relationshipName;
         var relationshipReferences = fieldMetadata.relationshipReferences;
         var relationshipNameField = relationshipReferences[0].nameField;
 
@@ -25,6 +25,7 @@
         var fieldName = component.get('v.fieldName');
 
         if(record === null) return;
+
         if(record.hasOwnProperty(fieldName)) {
             component.set('v.fieldValue', record[fieldName]);
         }

--- a/src/aura/outputField/outputFieldHelper.js
+++ b/src/aura/outputField/outputFieldHelper.js
@@ -8,7 +8,8 @@
 
         // Parent record name (used for REFERENCE fields)
         var relationshipName = fieldMetadata.relationshipName;// + '.' + fieldMetadata.relationshipNameField;
-        var relationshipNameField = fieldMetadata.relationshipNameField;
+        var relationshipReferences = fieldMetadata.relationshipReferences;
+        var relationshipNameField = relationshipReferences[Object.keys(relationshipReferences)[0]].name;
 
         if(record && record.hasOwnProperty(relationshipName)) {
             var parentRecord = record[relationshipName];

--- a/src/aura/sobjectMetadata/sobjectMetadata.cmp
+++ b/src/aura/sobjectMetadata/sobjectMetadata.cmp
@@ -13,4 +13,7 @@
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
     <aura:handler name="change" value="{!v.sobjectName}" action="{!c.clearCachedMetadata}" />
 
+    <!-- Markup -->
+    {!v.body}
+
 </aura:component>

--- a/src/aura/sobjectMetadata/sobjectMetadata.cmp
+++ b/src/aura/sobjectMetadata/sobjectMetadata.cmp
@@ -1,14 +1,16 @@
-<aura:component extensible="true" abstract="false" controller="LightningMetadataController">
+<aura:component extensible="true" controller="LightningMetadataController">
 
     <!-- Public Attributes -->
-    <aura:attribute name="sobjectName" type="String" required="true" />
-    <aura:attribute name="sobjectMetadata" type="Object" />
+    <aura:attribute name="sobjectName" type="String" />
+    <aura:method name="fetch" action="{!c.doInit}">
+        <aura:attribute name="callback" type="function"/>
+    </aura:method>
+
+    <!-- Private Attributes -->
+    <aura:attribute name="sobjectMetadata" type="Object" access="private" />
 
     <!-- Handlers -->
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
-    <aura:handler name="change" value="{!v.sobjectName}" action="{!c.doInit}" />
-
-    <!-- Markup -->
-    {!v.body}
+    <aura:handler name="change" value="{!v.sobjectName}" action="{!c.clearCachedMetadata}" />
 
 </aura:component>

--- a/src/aura/sobjectMetadata/sobjectMetadata.cmp
+++ b/src/aura/sobjectMetadata/sobjectMetadata.cmp
@@ -1,0 +1,14 @@
+<aura:component extensible="true" abstract="false" controller="LightningMetadataController">
+
+    <!-- Public Attributes -->
+    <aura:attribute name="sobjectName" type="String" required="true" />
+    <aura:attribute name="sobjectMetadata" type="Object" />
+
+    <!-- Handlers -->
+    <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
+    <aura:handler name="change" value="{!v.sobjectName}" action="{!c.doInit}" />
+
+    <!-- Markup -->
+    {!v.body}
+
+</aura:component>

--- a/src/aura/sobjectMetadata/sobjectMetadata.cmp
+++ b/src/aura/sobjectMetadata/sobjectMetadata.cmp
@@ -1,8 +1,10 @@
 <aura:component extensible="true" controller="LightningMetadataController">
 
     <!-- Public Attributes -->
-    <aura:attribute name="sobjectName" type="String" />
-    <aura:method name="fetch" action="{!c.doInit}">
+    <aura:attribute name="sobjectName" type="String" description="The API name of the SObject" />
+
+    <!-- Public Methods -->
+    <aura:method name="fetch" action="{!c.doInit}" description="(Optional) Callback function to use after fetching the metadata">
         <aura:attribute name="callback" type="function"/>
     </aura:method>
 

--- a/src/aura/sobjectMetadata/sobjectMetadata.cmp-meta.xml
+++ b/src/aura/sobjectMetadata/sobjectMetadata.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <description>sobjectMetadata</description>
+</AuraDefinitionBundle>

--- a/src/aura/sobjectMetadata/sobjectMetadataController.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataController.js
@@ -1,0 +1,6 @@
+({
+    doInit : function(component, event, helper) {
+        console.log('sobjectMetadata init');
+        helper.fetchSObjectMetadata(component, event);
+    }
+})

--- a/src/aura/sobjectMetadata/sobjectMetadataController.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataController.js
@@ -1,51 +1,8 @@
 ({
     doInit : function(component, event, helper) {
-        console.log('sobjectMetadata init');
         helper.fetchSObjectMetadata(component, event);
     },
     clearCachedMetadata : function(component, event, helper) {
         component.set('v.sobjectMetadata', null);
     }
-    // fetch : function(component, event, helper) {
-    //     console.log('sobjectMetadata load');
-    //     var params = event.getParam("arguments");
-    //     console.log(params);
-    //     /*var action = component.get("c.getAccounts");
-    //     action.setCallback(this, function(response) {
-    //         if (response.getState() === "SUCCESS") {
-    //             params.callback(null, response.getReturnValue());
-    //         } else {
-    //             params.callback(response.getError());
-    //         }
-    //     });
-    //     $A.enqueueAction(action);*/
-
-
-
-
-
-    //     var sobjectName = component.get('v.sobjectName');
-
-    //     if(!sobjectName) return;
-
-    //     var action = component.get('c.getSObjectMetadata');
-    //     action.setParams({
-    //         'sobjectName': sobjectName
-    //     });
-    //     action.setStorable();
-    //     action.setCallback(this, function(response) {
-    //         if(response.getState() === 'SUCCESS') {
-    //             var sobjectMetadata = response.getReturnValue();
-    //             console.log(sobjectMetadata);
-    //             component.set('v.sobjectMetadata', sobjectMetadata);
-    //             params.callback(null, response.getReturnValue());
-    //         } else if(response.getState() === 'ERROR') {
-    //             console.log('ERROR');
-    //             for(var i=0; i < response.getError().length; i++) {
-    //                console.log(response.getError()[i]);
-    //             }
-    //         }
-    //     });
-    //     $A.enqueueAction(action);
-    // }
 })

--- a/src/aura/sobjectMetadata/sobjectMetadataController.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataController.js
@@ -2,5 +2,50 @@
     doInit : function(component, event, helper) {
         console.log('sobjectMetadata init');
         helper.fetchSObjectMetadata(component, event);
+    },
+    clearCachedMetadata : function(component, event, helper) {
+        component.set('v.sobjectMetadata', null);
     }
+    // fetch : function(component, event, helper) {
+    //     console.log('sobjectMetadata load');
+    //     var params = event.getParam("arguments");
+    //     console.log(params);
+    //     /*var action = component.get("c.getAccounts");
+    //     action.setCallback(this, function(response) {
+    //         if (response.getState() === "SUCCESS") {
+    //             params.callback(null, response.getReturnValue());
+    //         } else {
+    //             params.callback(response.getError());
+    //         }
+    //     });
+    //     $A.enqueueAction(action);*/
+
+
+
+
+
+    //     var sobjectName = component.get('v.sobjectName');
+
+    //     if(!sobjectName) return;
+
+    //     var action = component.get('c.getSObjectMetadata');
+    //     action.setParams({
+    //         'sobjectName': sobjectName
+    //     });
+    //     action.setStorable();
+    //     action.setCallback(this, function(response) {
+    //         if(response.getState() === 'SUCCESS') {
+    //             var sobjectMetadata = response.getReturnValue();
+    //             console.log(sobjectMetadata);
+    //             component.set('v.sobjectMetadata', sobjectMetadata);
+    //             params.callback(null, response.getReturnValue());
+    //         } else if(response.getState() === 'ERROR') {
+    //             console.log('ERROR');
+    //             for(var i=0; i < response.getError().length; i++) {
+    //                console.log(response.getError()[i]);
+    //             }
+    //         }
+    //     });
+    //     $A.enqueueAction(action);
+    // }
 })

--- a/src/aura/sobjectMetadata/sobjectMetadataHelper.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataHelper.js
@@ -18,7 +18,6 @@
         action.setCallback(this, function(response) {
             if(response.getState() === 'SUCCESS') {
                 var sobjectMetadata = response.getReturnValue();
-                console.log(sobjectMetadata);
                 component.set('v.sobjectMetadata', sobjectMetadata);
 
                 if(params) params.callback(null, sobjectMetadata);

--- a/src/aura/sobjectMetadata/sobjectMetadataHelper.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataHelper.js
@@ -1,8 +1,18 @@
 ({
     fetchSObjectMetadata : function(component, event) {
+        var sobjectMetadata = component.get('v.sobjectMetadata');
+
+        // If we already have the sobject metadata cached, use the cache
+        if(sobjectMetadata) return;
+
+        var sobjectName = component.get('v.sobjectName');
+        var params = event.getParam('arguments');
+
+        if(!sobjectName) return;
+
         var action = component.get('c.getSObjectMetadata');
         action.setParams({
-            'sobjectName': component.get('v.sobjectName')
+            'sobjectName': sobjectName
         });
         action.setStorable();
         action.setCallback(this, function(response) {
@@ -10,6 +20,8 @@
                 var sobjectMetadata = response.getReturnValue();
                 console.log(sobjectMetadata);
                 component.set('v.sobjectMetadata', sobjectMetadata);
+
+                if(params) params.callback(null, sobjectMetadata);
             } else if(response.getState() === 'ERROR') {
                 console.log('ERROR');
                 for(var i=0; i < response.getError().length; i++) {

--- a/src/aura/sobjectMetadata/sobjectMetadataHelper.js
+++ b/src/aura/sobjectMetadata/sobjectMetadataHelper.js
@@ -1,0 +1,22 @@
+({
+    fetchSObjectMetadata : function(component, event) {
+        var action = component.get('c.getSObjectMetadata');
+        action.setParams({
+            'sobjectName': component.get('v.sobjectName')
+        });
+        action.setStorable();
+        action.setCallback(this, function(response) {
+            if(response.getState() === 'SUCCESS') {
+                var sobjectMetadata = response.getReturnValue();
+                console.log(sobjectMetadata);
+                component.set('v.sobjectMetadata', sobjectMetadata);
+            } else if(response.getState() === 'ERROR') {
+                console.log('ERROR');
+                for(var i=0; i < response.getError().length; i++) {
+                   console.log(response.getError()[i]);
+                }
+            }
+        });
+        $A.enqueueAction(action);
+    }
+})

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -20,7 +20,8 @@ public with sharing class LightningMetadataController {
         }
     }
 
-    @AuraEnabled
+    // TODO finish implementing and uncomment
+    /*@AuraEnabled
     public static List<FieldMetadata> getFieldSetMetadata(String sobjectName, String fieldSetName) {
         System.debug(LoggingLevel.INFO, 'Executing LightningMetadataController.getFieldSetMetadata(\'' + sobjectName + '\', \'' + fieldSetName + '\')');
 
@@ -35,7 +36,7 @@ public with sharing class LightningMetadataController {
             fieldSetMetadata.add(fieldMetadata);
         }
         return fieldSetMetadata;
-    }
+    }*/
 
     public class SObjectMetadata {
         @AuraEnabled public Boolean isAccessible  {get;private set;}
@@ -139,21 +140,21 @@ public with sharing class LightningMetadataController {
 
             this.fieldDescribe = Schema.getGlobalDescribe().get(sobjectName).getDescribe().fields.getMap().get(fieldName).getDescribe();
 
-            this.defaultValue            = this.fieldDescribe.getDefaultValue();
-            this.displayType             = this.fieldDescribe.getType().name();
-            this.inlineHelpText          = this.fieldDescribe.getInlineHelpText();
-            this.isAccessible            = this.fieldDescribe.isAccessible();
-            this.isCreateable            = this.fieldDescribe.isCreateable();
-            this.isDefaultedOnCreate     = this.fieldDescribe.isDefaultedOnCreate();
-            this.isFilterable            = this.fieldDescribe.isFilterable();
-            this.isNameField             = this.fieldDescribe.isNameField();
-            this.isSortable              = this.fieldDescribe.isSortable();
-            this.isUpdateable            = this.fieldDescribe.isUpdateable();
-            this.label                   = this.fieldDescribe.getLabel();
-            this.maxLength               = this.fieldDescribe.getLength();
-            this.relationshipName        = this.fieldDescribe.getRelationshipName();
-            this.relationshipNameField   = this.fieldDescribe.getReferenceTo() != null && !this.fieldDescribe.getReferenceTo().isEmpty() ? new SObjectMetadata(this.fieldDescribe.getReferenceTo()[0]).nameField : null;
-            this.required                = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
+            this.defaultValue          = this.fieldDescribe.getDefaultValue();
+            this.displayType           = this.fieldDescribe.getType().name();
+            this.inlineHelpText        = this.fieldDescribe.getInlineHelpText();
+            this.isAccessible          = this.fieldDescribe.isAccessible();
+            this.isCreateable          = this.fieldDescribe.isCreateable();
+            this.isDefaultedOnCreate   = this.fieldDescribe.isDefaultedOnCreate();
+            this.isFilterable          = this.fieldDescribe.isFilterable();
+            this.isNameField           = this.fieldDescribe.isNameField();
+            this.isSortable            = this.fieldDescribe.isSortable();
+            this.isUpdateable          = this.fieldDescribe.isUpdateable();
+            this.label                 = this.fieldDescribe.getLabel();
+            this.maxLength             = this.fieldDescribe.getLength();
+            this.relationshipName      = this.fieldDescribe.getRelationshipName();
+            this.relationshipNameField = this.fieldDescribe.getReferenceTo() != null && !this.fieldDescribe.getReferenceTo().isEmpty() ? new SObjectMetadata(this.fieldDescribe.getReferenceTo()[0]).nameField : null;
+            this.required              = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
 
             this.setPicklistOptions();
             this.setRelationshipReferences();
@@ -172,6 +173,7 @@ public with sharing class LightningMetadataController {
         private void setRelationshipReferences() {
             this.relationshipReferences = new List<String>();
             for(Schema.SObjectType sobjectType : this.fieldDescribe.getReferenceTo()) {
+                // TODO convert to instances of SObjectMetadata instead of strings
                 this.relationshipReferences.add(String.valueOf(sobjectType));
             }
         }

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -198,7 +198,7 @@ public with sharing class LightningMetadataController {
         private Schema.PicklistEntry picklistEntry;
 
         public PicklistEntryMetadata() {
-            this.label          = '';
+            this.label          = '--None--';
             this.value          = '';
             this.isDefaultValue = false;
         }

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -50,6 +50,7 @@ public with sharing class LightningMetadataController {
         @AuraEnabled public String labelPlural    {get;private set;}
         @AuraEnabled public String name           {get;private set;}
         @AuraEnabled public String nameField      {get;private set;}
+        @AuraEnabled public String tabIcon        {get;private set;}
 
         public Schema.DescribeSObjectResult sobjectDescribe {get;private set;}
 
@@ -73,6 +74,7 @@ public with sharing class LightningMetadataController {
             this.labelPlural   = this.sobjectDescribe.getLabelPlural();
 
             this.setNameField();
+            this.setTabIcon();
         }
 
         private void setNameField() {
@@ -83,6 +85,24 @@ public with sharing class LightningMetadataController {
 
                 this.nameField = fieldDescribe.getName();
                 break;
+            }
+        }
+
+        private void setTabIcon() {
+            for(Schema.DescribeTabSetResult tabSetResult : Schema.describeTabs()) {
+                for(Schema.DescribeTabResult tabResult : tabSetResult.getTabs()) {
+                    if(tabResult.getSObjectName() != this.name) continue;
+
+                    String iconType = tabResult.isCustom() ? 'custom' : 'standard';
+                    String svgIconName;
+                    for(Schema.DescribeIconResult icon : tabResult.getIcons()) {
+                        if(icon.getContentType() == 'image/svg+xml') {
+                            svgIconName = icon.getUrl().substringAfterLast('/').replace('.svg', '');
+                        }
+                    }
+                    this.tabIcon = iconType + ':' + svgIconName;
+                    break;
+                }
             }
         }
     }

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -109,25 +109,25 @@ public with sharing class LightningMetadataController {
     }
 
     public class FieldMetadata {
-        @AuraEnabled public Boolean isAccessible                                {get;private set;}
-        @AuraEnabled public Boolean isCreateable                                {get;private set;}
-        @AuraEnabled public Boolean isDefaultedOnCreate                         {get;private set;}
-        @AuraEnabled public Boolean isFilterable                                {get;private set;}
-        @AuraEnabled public Boolean isNameField                                 {get;private set;}
-        @AuraEnabled public Boolean isSortable                                  {get;private set;}
-        @AuraEnabled public Boolean isUpdateable                                {get;private set;}
-        @AuraEnabled public Boolean required                                    {get;private set;}
-        @AuraEnabled public Integer maxLength                                   {get;private set;}
-        @AuraEnabled public List<PicklistEntryMetadata> picklistOptions         {get;private set;}
-        @AuraEnabled public Object defaultValue                                 {get;private set;}
-        @AuraEnabled public SObjectMetadata sobjectMetadata                     {get;private set;}
-        @AuraEnabled public String displayType                                  {get;private set;}
-        @AuraEnabled public String inlineHelpText                               {get;private set;}
-        @AuraEnabled public String label                                        {get;private set;}
-        @AuraEnabled public String name                                         {get;private set;}
-        @AuraEnabled public String relationshipName                             {get;private set;}
-        @AuraEnabled public Map<String, SObjectMetadata> relationshipReferences {get;private set;}
-        @AuraEnabled public String sobjectName                                  {get;private set;}
+        @AuraEnabled public Boolean isAccessible                         {get;private set;}
+        @AuraEnabled public Boolean isCreateable                         {get;private set;}
+        @AuraEnabled public Boolean isDefaultedOnCreate                  {get;private set;}
+        @AuraEnabled public Boolean isFilterable                         {get;private set;}
+        @AuraEnabled public Boolean isNameField                          {get;private set;}
+        @AuraEnabled public Boolean isSortable                           {get;private set;}
+        @AuraEnabled public Boolean isUpdateable                         {get;private set;}
+        @AuraEnabled public Boolean required                             {get;private set;}
+        @AuraEnabled public Integer maxLength                            {get;private set;}
+        @AuraEnabled public List<PicklistEntryMetadata> picklistOptions  {get;private set;}
+        @AuraEnabled public Object defaultValue                          {get;private set;}
+        @AuraEnabled public SObjectMetadata sobjectMetadata              {get;private set;}
+        @AuraEnabled public String displayType                           {get;private set;}
+        @AuraEnabled public String inlineHelpText                        {get;private set;}
+        @AuraEnabled public String label                                 {get;private set;}
+        @AuraEnabled public String name                                  {get;private set;}
+        @AuraEnabled public String relationshipName                      {get;private set;}
+        @AuraEnabled public List<SObjectMetadata> relationshipReferences {get;private set;}
+        @AuraEnabled public String sobjectName                           {get;private set;}
 
         public Schema.DescribeFieldResult fieldDescribe {get;private set;}
 
@@ -169,9 +169,9 @@ public with sharing class LightningMetadataController {
         }
 
         private void setRelationshipReferences() {
-            this.relationshipReferences = new Map<String, SObjectMetadata>();
+            this.relationshipReferences = new List<SObjectMetadata>();
             for(Schema.SObjectType sobjectType : this.fieldDescribe.getReferenceTo()) {
-                this.relationshipReferences.put(String.valueOf(sobjectType), new SObjectMetadata(sobjectType));
+                this.relationshipReferences.add(new SObjectMetadata(sobjectType));
             }
         }
     }

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -41,6 +41,7 @@ public with sharing class LightningMetadataController {
     public class SObjectMetadata {
         @AuraEnabled public Boolean isAccessible  {get;private set;}
         @AuraEnabled public Boolean isCreateable  {get;private set;}
+        @AuraEnabled public Boolean isCustom      {get;private set;}
         @AuraEnabled public Boolean isDeletable   {get;private set;}
         @AuraEnabled public Boolean isMergeable   {get;private set;}
         @AuraEnabled public Boolean isQueryable   {get;private set;}
@@ -65,6 +66,7 @@ public with sharing class LightningMetadataController {
 
             this.isAccessible  = this.sobjectDescribe.isAccessible();
             this.isCreateable  = this.sobjectDescribe.isCreateable();
+            this.isCustom      = this.sobjectDescribe.isCustom();
             this.isDeletable   = this.sobjectDescribe.isDeletable();
             this.isMergeable   = this.sobjectDescribe.isMergeable();
             this.isQueryable   = this.sobjectDescribe.isQueryable();
@@ -97,12 +99,12 @@ public with sharing class LightningMetadataController {
                     String iconType = tabResult.isCustom() ? 'custom' : 'standard';
                     String svgIconName;
                     for(Schema.DescribeIconResult icon : tabResult.getIcons()) {
-                        if(icon.getContentType() == 'image/svg+xml') {
-                            svgIconName = icon.getUrl().substringAfterLast('/').replace('.svg', '');
-                        }
+                        if(icon.getContentType() != 'image/svg+xml') continue;
+
+                        svgIconName = icon.getUrl().substringAfterLast('/').replace('.svg', '');
+                        this.tabIcon = iconType + ':' + svgIconName;
+                        break;
                     }
-                    this.tabIcon = iconType + ':' + svgIconName;
-                    break;
                 }
             }
         }
@@ -111,6 +113,7 @@ public with sharing class LightningMetadataController {
     public class FieldMetadata {
         @AuraEnabled public Boolean isAccessible                         {get;private set;}
         @AuraEnabled public Boolean isCreateable                         {get;private set;}
+        @AuraEnabled public Boolean isCustom                             {get;private set;}
         @AuraEnabled public Boolean isDefaultedOnCreate                  {get;private set;}
         @AuraEnabled public Boolean isFilterable                         {get;private set;}
         @AuraEnabled public Boolean isNameField                          {get;private set;}
@@ -139,20 +142,21 @@ public with sharing class LightningMetadataController {
 
             this.fieldDescribe = Schema.getGlobalDescribe().get(sobjectName).getDescribe().fields.getMap().get(fieldName).getDescribe();
 
-            this.defaultValue          = this.fieldDescribe.getDefaultValue();
-            this.displayType           = this.fieldDescribe.getType().name();
-            this.inlineHelpText        = this.fieldDescribe.getInlineHelpText();
-            this.isAccessible          = this.fieldDescribe.isAccessible();
-            this.isCreateable          = this.fieldDescribe.isCreateable();
-            this.isDefaultedOnCreate   = this.fieldDescribe.isDefaultedOnCreate();
-            this.isFilterable          = this.fieldDescribe.isFilterable();
-            this.isNameField           = this.fieldDescribe.isNameField();
-            this.isSortable            = this.fieldDescribe.isSortable();
-            this.isUpdateable          = this.fieldDescribe.isUpdateable();
-            this.label                 = this.fieldDescribe.getLabel();
-            this.maxLength             = this.fieldDescribe.getLength();
-            this.relationshipName      = this.fieldDescribe.getRelationshipName();
-            this.required              = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
+            this.defaultValue        = this.fieldDescribe.getDefaultValue();
+            this.displayType         = this.fieldDescribe.getType().name();
+            this.inlineHelpText      = this.fieldDescribe.getInlineHelpText();
+            this.isAccessible        = this.fieldDescribe.isAccessible();
+            this.isCreateable        = this.fieldDescribe.isCreateable();
+            this.isCustom            = this.fieldDescribe.isCustom();
+            this.isDefaultedOnCreate = this.fieldDescribe.isDefaultedOnCreate();
+            this.isFilterable        = this.fieldDescribe.isFilterable();
+            this.isNameField         = this.fieldDescribe.isNameField();
+            this.isSortable          = this.fieldDescribe.isSortable();
+            this.isUpdateable        = this.fieldDescribe.isUpdateable();
+            this.label               = this.fieldDescribe.getLabel();
+            this.maxLength           = this.fieldDescribe.getLength();
+            this.relationshipName    = this.fieldDescribe.getRelationshipName();
+            this.required            = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
 
             this.setPicklistOptions();
             this.setRelationshipReferences();

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -109,26 +109,25 @@ public with sharing class LightningMetadataController {
     }
 
     public class FieldMetadata {
-        @AuraEnabled public Boolean isAccessible                        {get;private set;}
-        @AuraEnabled public Boolean isCreateable                        {get;private set;}
-        @AuraEnabled public Boolean isDefaultedOnCreate                 {get;private set;}
-        @AuraEnabled public Boolean isFilterable                        {get;private set;}
-        @AuraEnabled public Boolean isNameField                         {get;private set;}
-        @AuraEnabled public Boolean isSortable                          {get;private set;}
-        @AuraEnabled public Boolean isUpdateable                        {get;private set;}
-        @AuraEnabled public Boolean required                            {get;private set;}
-        @AuraEnabled public Integer maxLength                           {get;private set;}
-        @AuraEnabled public List<PicklistEntryMetadata> picklistOptions {get;private set;}
-        @AuraEnabled public Object defaultValue                         {get;private set;}
-        @AuraEnabled public SObjectMetadata sobjectMetadata             {get;private set;}
-        @AuraEnabled public String displayType                          {get;private set;}
-        @AuraEnabled public String inlineHelpText                       {get;private set;}
-        @AuraEnabled public String label                                {get;private set;}
-        @AuraEnabled public String name                                 {get;private set;}
-        @AuraEnabled public String relationshipName                     {get;private set;}
-        @AuraEnabled public List<String> relationshipReferences         {get;private set;}
-        @AuraEnabled public String relationshipNameField                {get;private set;}
-        @AuraEnabled public String sobjectName                          {get;private set;}
+        @AuraEnabled public Boolean isAccessible                                {get;private set;}
+        @AuraEnabled public Boolean isCreateable                                {get;private set;}
+        @AuraEnabled public Boolean isDefaultedOnCreate                         {get;private set;}
+        @AuraEnabled public Boolean isFilterable                                {get;private set;}
+        @AuraEnabled public Boolean isNameField                                 {get;private set;}
+        @AuraEnabled public Boolean isSortable                                  {get;private set;}
+        @AuraEnabled public Boolean isUpdateable                                {get;private set;}
+        @AuraEnabled public Boolean required                                    {get;private set;}
+        @AuraEnabled public Integer maxLength                                   {get;private set;}
+        @AuraEnabled public List<PicklistEntryMetadata> picklistOptions         {get;private set;}
+        @AuraEnabled public Object defaultValue                                 {get;private set;}
+        @AuraEnabled public SObjectMetadata sobjectMetadata                     {get;private set;}
+        @AuraEnabled public String displayType                                  {get;private set;}
+        @AuraEnabled public String inlineHelpText                               {get;private set;}
+        @AuraEnabled public String label                                        {get;private set;}
+        @AuraEnabled public String name                                         {get;private set;}
+        @AuraEnabled public String relationshipName                             {get;private set;}
+        @AuraEnabled public Map<String, SObjectMetadata> relationshipReferences {get;private set;}
+        @AuraEnabled public String sobjectName                                  {get;private set;}
 
         public Schema.DescribeFieldResult fieldDescribe {get;private set;}
 
@@ -153,7 +152,6 @@ public with sharing class LightningMetadataController {
             this.label                 = this.fieldDescribe.getLabel();
             this.maxLength             = this.fieldDescribe.getLength();
             this.relationshipName      = this.fieldDescribe.getRelationshipName();
-            this.relationshipNameField = this.fieldDescribe.getReferenceTo() != null && !this.fieldDescribe.getReferenceTo().isEmpty() ? new SObjectMetadata(this.fieldDescribe.getReferenceTo()[0]).nameField : null;
             this.required              = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
 
             this.setPicklistOptions();
@@ -171,10 +169,9 @@ public with sharing class LightningMetadataController {
         }
 
         private void setRelationshipReferences() {
-            this.relationshipReferences = new List<String>();
+            this.relationshipReferences = new Map<String, SObjectMetadata>();
             for(Schema.SObjectType sobjectType : this.fieldDescribe.getReferenceTo()) {
-                // TODO convert to instances of SObjectMetadata instead of strings
-                this.relationshipReferences.add(String.valueOf(sobjectType));
+                this.relationshipReferences.put(String.valueOf(sobjectType), new SObjectMetadata(sobjectType));
             }
         }
     }

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -39,22 +39,25 @@ public with sharing class LightningMetadataController {
     }*/
 
     public class SObjectMetadata {
-        @AuraEnabled public Boolean isAccessible  {get;private set;}
-        @AuraEnabled public Boolean isCreateable  {get;private set;}
-        @AuraEnabled public Boolean isCustom      {get;private set;}
-        @AuraEnabled public Boolean isDeletable   {get;private set;}
-        @AuraEnabled public Boolean isMergeable   {get;private set;}
-        @AuraEnabled public Boolean isQueryable   {get;private set;}
-        @AuraEnabled public Boolean isSearchable  {get;private set;}
-        @AuraEnabled public Boolean isUndeletable {get;private set;}
-        @AuraEnabled public Boolean isUpdateable  {get;private set;}
-        @AuraEnabled public String label          {get;private set;}
-        @AuraEnabled public String labelPlural    {get;private set;}
-        @AuraEnabled public String name           {get;private set;}
-        @AuraEnabled public String nameField      {get;private set;}
-        @AuraEnabled public String tabIcon        {get;private set;}
+        @AuraEnabled public Boolean isAccessible    {get;private set;}
+        @AuraEnabled public Boolean isCreateable    {get;private set;}
+        @AuraEnabled public Boolean isCustom        {get;private set;}
+        @AuraEnabled public Boolean isCustomSetting {get;private set;}
+        @AuraEnabled public Boolean isDeletable     {get;private set;}
+        @AuraEnabled public Boolean isMergeable     {get;private set;}
+        @AuraEnabled public Boolean isQueryable     {get;private set;}
+        @AuraEnabled public Boolean isSearchable    {get;private set;}
+        @AuraEnabled public Boolean isUndeletable   {get;private set;}
+        @AuraEnabled public Boolean isUpdateable    {get;private set;}
+        @AuraEnabled public String keyPrefix        {get;private set;}
+        @AuraEnabled public String label            {get;private set;}
+        @AuraEnabled public String labelPlural      {get;private set;}
+        @AuraEnabled public String localName        {get;private set;}
+        @AuraEnabled public String name             {get;private set;}
+        @AuraEnabled public String nameField        {get;private set;}
+        @AuraEnabled public String tabIcon          {get;private set;}
 
-        public Schema.DescribeSObjectResult sobjectDescribe {get;private set;}
+        private Schema.DescribeSObjectResult sobjectDescribe {get;private set;}
 
         public SObjectMetadata(Schema.SObjectType sobjectType) {
             this(sobjectType.getDescribe().getName());
@@ -64,17 +67,20 @@ public with sharing class LightningMetadataController {
             this.name            = sobjectName;
             this.sobjectDescribe = Schema.getGlobalDescribe().get(sobjectName).getDescribe();
 
-            this.isAccessible  = this.sobjectDescribe.isAccessible();
-            this.isCreateable  = this.sobjectDescribe.isCreateable();
-            this.isCustom      = this.sobjectDescribe.isCustom();
-            this.isDeletable   = this.sobjectDescribe.isDeletable();
-            this.isMergeable   = this.sobjectDescribe.isMergeable();
-            this.isQueryable   = this.sobjectDescribe.isQueryable();
-            this.isSearchable  = this.sobjectDescribe.isSearchable();
-            this.isUndeletable = this.sobjectDescribe.isUndeletable();
-            this.isUpdateable  = this.sobjectDescribe.isUpdateable();
-            this.label         = this.sobjectDescribe.getLabel();
-            this.labelPlural   = this.sobjectDescribe.getLabelPlural();
+            this.isAccessible    = this.sobjectDescribe.isAccessible();
+            this.isCreateable    = this.sobjectDescribe.isCreateable();
+            this.isCustom        = this.sobjectDescribe.isCustom();
+            this.isCustomSetting = this.sobjectDescribe.isCustomSetting();
+            this.isDeletable     = this.sobjectDescribe.isDeletable();
+            this.isMergeable     = this.sobjectDescribe.isMergeable();
+            this.isQueryable     = this.sobjectDescribe.isQueryable();
+            this.isSearchable    = this.sobjectDescribe.isSearchable();
+            this.isUndeletable   = this.sobjectDescribe.isUndeletable();
+            this.isUpdateable    = this.sobjectDescribe.isUpdateable();
+            this.keyPrefix       = this.sobjectDescribe.getKeyPrefix();
+            this.label           = this.sobjectDescribe.getLabel();
+            this.labelPlural     = this.sobjectDescribe.getLabelPlural();
+            this.localName       = this.sobjectDescribe.getLocalName();
 
             this.setNameField();
             this.setTabIcon();
@@ -112,10 +118,12 @@ public with sharing class LightningMetadataController {
 
     public class FieldMetadata {
         @AuraEnabled public Boolean isAccessible                         {get;private set;}
+        @AuraEnabled public Boolean isCalculated                         {get;private set;}
         @AuraEnabled public Boolean isCreateable                         {get;private set;}
         @AuraEnabled public Boolean isCustom                             {get;private set;}
         @AuraEnabled public Boolean isDefaultedOnCreate                  {get;private set;}
         @AuraEnabled public Boolean isFilterable                         {get;private set;}
+        @AuraEnabled public Boolean isGroupable                          {get;private set;}
         @AuraEnabled public Boolean isNameField                          {get;private set;}
         @AuraEnabled public Boolean isSortable                           {get;private set;}
         @AuraEnabled public Boolean isUpdateable                         {get;private set;}
@@ -132,7 +140,7 @@ public with sharing class LightningMetadataController {
         @AuraEnabled public List<SObjectMetadata> relationshipReferences {get;private set;}
         @AuraEnabled public String sobjectName                           {get;private set;}
 
-        public Schema.DescribeFieldResult fieldDescribe {get;private set;}
+        private Schema.DescribeFieldResult fieldDescribe {get;private set;}
 
         public FieldMetadata(String sobjectName, String fieldName) {
             this.sobjectName     = sobjectName;
@@ -146,10 +154,12 @@ public with sharing class LightningMetadataController {
             this.displayType         = this.fieldDescribe.getType().name();
             this.inlineHelpText      = this.fieldDescribe.getInlineHelpText();
             this.isAccessible        = this.fieldDescribe.isAccessible();
+            this.isCalculated        = this.fieldDescribe.isCalculated();
             this.isCreateable        = this.fieldDescribe.isCreateable();
             this.isCustom            = this.fieldDescribe.isCustom();
             this.isDefaultedOnCreate = this.fieldDescribe.isDefaultedOnCreate();
             this.isFilterable        = this.fieldDescribe.isFilterable();
+            this.isGroupable         = this.fieldDescribe.isGroupable();
             this.isNameField         = this.fieldDescribe.isNameField();
             this.isSortable          = this.fieldDescribe.isSortable();
             this.isUpdateable        = this.fieldDescribe.isUpdateable();
@@ -180,7 +190,7 @@ public with sharing class LightningMetadataController {
         }
     }
 
-    private class PicklistEntryMetadata {
+    public class PicklistEntryMetadata {
         @AuraEnabled public String label           {get;private set;}
         @AuraEnabled public String value           {get;private set;}
         @AuraEnabled public Boolean isDefaultValue {get;private set;}

--- a/src/classes/LightningMetadataController.cls
+++ b/src/classes/LightningMetadataController.cls
@@ -125,6 +125,7 @@ public with sharing class LightningMetadataController {
         @AuraEnabled public String label                                {get;private set;}
         @AuraEnabled public String name                                 {get;private set;}
         @AuraEnabled public String relationshipName                     {get;private set;}
+        @AuraEnabled public List<String> relationshipReferences         {get;private set;}
         @AuraEnabled public String relationshipNameField                {get;private set;}
         @AuraEnabled public String sobjectName                          {get;private set;}
 
@@ -155,6 +156,7 @@ public with sharing class LightningMetadataController {
             this.required                = this.fieldDescribe.isNillable() == false; // If a field is NOT nillable, then it's required
 
             this.setPicklistOptions();
+            this.setRelationshipReferences();
         }
 
         private void setPicklistOptions() {
@@ -164,6 +166,13 @@ public with sharing class LightningMetadataController {
             this.picklistOptions.add(new PicklistEntryMetadata()); // Empty picklist value
             for(Schema.PicklistEntry picklistEntry : this.fieldDescribe.getPickListValues()) {
                 this.picklistOptions.add(new PicklistEntryMetadata(picklistEntry));
+            }
+        }
+
+        private void setRelationshipReferences() {
+            this.relationshipReferences = new List<String>();
+            for(Schema.SObjectType sobjectType : this.fieldDescribe.getReferenceTo()) {
+                this.relationshipReferences.add(String.valueOf(sobjectType));
             }
         }
     }

--- a/src/classes/LightningMetadataController.cls-meta.xml
+++ b/src/classes/LightningMetadataController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>41.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LightningMetadataController_Tests.cls
+++ b/src/classes/LightningMetadataController_Tests.cls
@@ -16,6 +16,20 @@ private class LightningMetadataController_Tests {
     }
 
     @isTest
+    static void it_should_throw_an_exception_for_invalid_sobject() {
+        String sobjectName = 'FakeObject';
+
+        Test.startTest();
+        try {
+            LightningMetadataController.SObjectMetadata sobjectMetadata = LightningMetadataController.getSObjectMetadata(sobjectName);
+            System.assert(false, 'Exception expected here');
+        } catch(Exception ex) {
+            System.assert(ex instanceOf AuraHandledException);
+        }
+        Test.stopTest();
+    }
+
+    @isTest
     static void it_should_return_field_metadata() {
         String sobjectName = 'Account';
         String fieldName = 'Type';
@@ -29,6 +43,21 @@ private class LightningMetadataController_Tests {
         System.assertEquals(sobjectName, fieldMetadata.sobjectName);
         System.assertEquals(fieldName, fieldMetadata.name);
         System.assertEquals(fieldDescribe.getLabel(), fieldMetadata.label);
+    }
+
+    @isTest
+    static void it_should_throw_an_exception_for_invalid_field() {
+        String sobjectName = 'Account';
+        String fieldName = 'FakeField';
+
+        Test.startTest();
+        try {
+            LightningMetadataController.FieldMetadata fieldMetadata = LightningMetadataController.getFieldMetadata(sobjectName, fieldName);
+            System.assert(false, 'Exception expected here');
+        } catch(Exception ex) {
+            System.assert(ex instanceOf AuraHandledException);
+        }
+        Test.stopTest();
     }
 
 }

--- a/src/classes/LightningMetadataController_Tests.cls-meta.xml
+++ b/src/classes/LightningMetadataController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>40.0</apiVersion>
+    <apiVersion>41.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -1,0 +1,34 @@
+public with sharing class LookupController {
+
+    @AuraEnabled
+    public static String search(String sobjectName, String fld_API_Text, String fld_API_Val, Integer limitCount, String fld_API_Search, String searchText) {
+        searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
+
+        String query = 'SELECT ' + fld_API_Text + ', ' + fld_API_Val
+            + ' FROM ' + sobjectName
+            + ' WHERE ' + fld_API_Search + ' LIKE ' + searchText
+            + ' ORDER BY LastViewedDate'
+            + ' LIMIT ' + limitCount;
+        System.debug('query=' + query);
+
+        List<MatchingRecord> searchResults = new List<MatchingRecord>();
+        for(SObject record : Database.query(query)) {
+            MatchingRecord matchingRecord = new MatchingRecord();
+            matchingRecord.displayText = String.valueOf(record.get(fld_API_Text));
+            matchingRecord.record      = record;
+            matchingRecord.recordId    = String.valueOf(record.get(fld_API_Val));
+            matchingRecord.sobjectName = sobjectName;
+            searchResults.add(matchingRecord);
+        }
+
+        return JSON.serialize(searchResults);
+    }
+
+    public class MatchingRecord {
+        public SObject record     {get;set;}
+        public String displayText {get;set;}
+        public String recordId    {get;set;}
+        public String sobjectName {get;set;}
+    }
+
+}

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -1,4 +1,3 @@
-
 public with sharing class LookupController {
 
     @AuraEnabled

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -1,12 +1,12 @@
 public with sharing class LookupController {
 
     @AuraEnabled
-    public static String search(String sobjectName, String fld_API_Text, String fld_API_Val, Integer limitCount, String fld_API_Search, String searchText) {
+    public static String search(String sobjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
         searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
 
-        String query = 'SELECT ' + fld_API_Text + ', ' + fld_API_Val
+        String query = 'SELECT Id, ' + displayTextFieldName // + ', ' + fieldName
             + ' FROM ' + sobjectName
-            + ' WHERE ' + fld_API_Search + ' LIKE ' + searchText
+            + ' WHERE ' + searchFieldName + ' LIKE ' + searchText
             + ' ORDER BY LastViewedDate'
             + ' LIMIT ' + limitCount;
         System.debug('query=' + query);
@@ -14,9 +14,9 @@ public with sharing class LookupController {
         List<MatchingRecord> searchResults = new List<MatchingRecord>();
         for(SObject record : Database.query(query)) {
             MatchingRecord matchingRecord = new MatchingRecord();
-            matchingRecord.displayText = String.valueOf(record.get(fld_API_Text));
+            matchingRecord.displayText = String.valueOf(record.get(displayTextFieldName));
             matchingRecord.record      = record;
-            matchingRecord.recordId    = String.valueOf(record.get(fld_API_Val));
+            matchingRecord.recordId    = String.valueOf(record.get('Id'));
             matchingRecord.sobjectName = sobjectName;
             searchResults.add(matchingRecord);
         }

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -2,34 +2,38 @@ public with sharing class LookupController {
 
     @AuraEnabled
     public static String search(String parentSObjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
-        Schema.DescribeSObjectResult parentSObjectDescribe = Schema.getGlobalDescribe().get(parentSObjectName).getDescribe();
-        LightningMetadataController.SObjectMetadata parentSObjectMetadata = new LightningMetadataController.SObjectMetadata(parentSObjectName);
+        try {
+            Schema.DescribeSObjectResult parentSObjectDescribe = Schema.getGlobalDescribe().get(parentSObjectName).getDescribe();
+            LightningMetadataController.SObjectMetadata parentSObjectMetadata = new LightningMetadataController.SObjectMetadata(parentSObjectName);
 
-        String query = 'SELECT Id, ' + displayTextFieldName
-            + ' FROM ' + parentSObjectName;
+            String query = 'SELECT Id, ' + displayTextFieldName
+                + ' FROM ' + parentSObjectName;
 
-        if(searchText != null) {
-            searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
-            query += ' WHERE ' + searchFieldName + ' LIKE ' + searchText;
+            if(searchText != null) {
+                searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
+                query += ' WHERE ' + searchFieldName + ' LIKE ' + searchText;
+            }
+
+            String sortByField = parentSObjectDescribe.fields.getMap().containsKey('LastViewedDate') ? 'LastViewedDate' : parentSObjectMetadata.nameField;
+            query += ' ORDER BY ' + sortByField
+                + ' LIMIT ' + limitCount;
+
+            System.debug('query=' + query);
+
+            List<MatchingRecord> searchResults = new List<MatchingRecord>();
+            for(SObject record : Database.query(query)) {
+                MatchingRecord matchingRecord = new MatchingRecord();
+                matchingRecord.displayText = String.valueOf(record.get(displayTextFieldName));
+                matchingRecord.record      = record;
+                matchingRecord.sobjectName = parentSObjectName;
+                searchResults.add(matchingRecord);
+            }
+
+            System.debug(JSON.serialize(searchResults));
+            return JSON.serialize(searchResults);
+        } catch(Exception ex) {
+            throw new AuraHandledException(ex.getMessage());
         }
-
-        String sortByField = parentSObjectDescribe.fields.getMap().containsKey('LastViewedDate') ? 'LastViewedDate' : parentSObjectMetadata.nameField;
-        query += ' ORDER BY ' + sortByField
-            + ' LIMIT ' + limitCount;
-
-        System.debug('query=' + query);
-
-        List<MatchingRecord> searchResults = new List<MatchingRecord>();
-        for(SObject record : Database.query(query)) {
-            MatchingRecord matchingRecord = new MatchingRecord();
-            matchingRecord.displayText = String.valueOf(record.get(displayTextFieldName));
-            matchingRecord.record      = record;
-            matchingRecord.sobjectName = parentSObjectName;
-            searchResults.add(matchingRecord);
-        }
-
-        System.debug(JSON.serialize(searchResults));
-        return JSON.serialize(searchResults);
     }
 
     public class MatchingRecord {

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -10,12 +10,12 @@ public with sharing class LookupController {
             String query = 'SELECT Id, ' + displayTextFieldName
                 + ' FROM ' + parentSObjectName;
 
-            if(searchText != null) {
+            if(!String.isEmpty(searchText)) {
                 searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
                 query += ' WHERE ' + searchFieldName + ' LIKE ' + searchText;
             }
 
-            String sortByField = parentSObjectDescribe.fields.getMap().containsKey('LastViewedDate') ? 'LastViewedDate' : parentSObjectMetadata.nameField;
+            String sortByField = parentSObjectDescribe.fields.getMap().containsKey('LastViewedDate') ? 'LastViewedDate DESC NULLS LAST' : parentSObjectMetadata.nameField;
             query += ' ORDER BY ' + sortByField
                 + ' LIMIT ' + limitCount;
 

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -1,7 +1,8 @@
+
 public with sharing class LookupController {
 
     @AuraEnabled
-    public static String search(String parentSObjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
+    public static List<MatchingRecord> search(String parentSObjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
         try {
             Schema.DescribeSObjectResult parentSObjectDescribe = Schema.getGlobalDescribe().get(parentSObjectName).getDescribe();
             LightningMetadataController.SObjectMetadata parentSObjectMetadata = new LightningMetadataController.SObjectMetadata(parentSObjectName);
@@ -22,24 +23,45 @@ public with sharing class LookupController {
 
             List<MatchingRecord> searchResults = new List<MatchingRecord>();
             for(SObject record : Database.query(query)) {
-                MatchingRecord matchingRecord = new MatchingRecord();
-                matchingRecord.displayText = String.valueOf(record.get(displayTextFieldName));
-                matchingRecord.record      = record;
-                matchingRecord.sobjectName = parentSObjectName;
+                MatchingRecord matchingRecord = new MatchingRecord(record);
                 searchResults.add(matchingRecord);
             }
 
-            System.debug(JSON.serialize(searchResults));
-            return JSON.serialize(searchResults);
+            //System.debug(JSON.serialize(searchResults));
+            return searchResults;
         } catch(Exception ex) {
             throw new AuraHandledException(ex.getMessage());
         }
     }
 
+    @AuraEnabled
+    public static MatchingRecord getRecord(Id recordId) {
+        if(recordId == null) return null;
+
+        Schema.SObjectType sobjectType = recordId.getSObjectType();
+        LightningMetadataController.SObjectMetadata sobjectMetadata = new LightningMetadataController.SObjectMetadata(sobjectType);
+        List<String> fields = new List<String>{'Id', sobjectMetadata.nameField};
+
+        String query = 'SELECT ' + String.join(fields, ', ')
+            + ' FROM ' + sobjectMetadata.name
+            + ' WHERE Id = \'' + recordId + '\'';
+
+        SObject record = Database.query(query);
+        return new MatchingRecord(record);
+    }
+
     public class MatchingRecord {
-        public SObject record     {get;set;}
-        public String displayText {get;set;}
-        public String sobjectName {get;set;}
+        @AuraEnabled public SObject record     {get;private set;}
+        @AuraEnabled public String displayText {get;private set;}
+        @AuraEnabled public String sobjectName {get;private set;}
+
+        public MatchingRecord(SObject record) {
+            this.record = record;
+
+            LightningMetadataController.SObjectMetadata sobjectMetadata = new LightningMetadataController.SObjectMetadata(record.getSObjectType());
+            this.sobjectName = sobjectMetadata.name;
+            this.displayText = (String)record.get(sobjectMetadata.nameField);
+        }
     }
 
 }

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -2,6 +2,9 @@ public with sharing class LookupController {
 
     @AuraEnabled
     public static String search(String parentSObjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
+        Schema.DescribeSObjectResult parentSObjectDescribe = Schema.getGlobalDescribe().get(parentSObjectName).getDescribe();
+        LightningMetadataController.SObjectMetadata parentSObjectMetadata = new LightningMetadataController.SObjectMetadata(parentSObjectName);
+
         String query = 'SELECT Id, ' + displayTextFieldName
             + ' FROM ' + parentSObjectName;
 
@@ -10,7 +13,8 @@ public with sharing class LookupController {
             query += ' WHERE ' + searchFieldName + ' LIKE ' + searchText;
         }
 
-        query += ' ORDER BY LastViewedDate'
+        String sortByField = parentSObjectDescribe.fields.getMap().containsKey('LastViewedDate') ? 'LastViewedDate' : parentSObjectMetadata.nameField;
+        query += ' ORDER BY ' + sortByField
             + ' LIMIT ' + limitCount;
 
         System.debug('query=' + query);

--- a/src/classes/LookupController.cls
+++ b/src/classes/LookupController.cls
@@ -1,14 +1,18 @@
 public with sharing class LookupController {
 
     @AuraEnabled
-    public static String search(String sobjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
-        searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
+    public static String search(String parentSObjectName, String searchFieldName, String searchText, String displayTextFieldName, Integer limitCount) {
+        String query = 'SELECT Id, ' + displayTextFieldName
+            + ' FROM ' + parentSObjectName;
 
-        String query = 'SELECT Id, ' + displayTextFieldName // + ', ' + fieldName
-            + ' FROM ' + sobjectName
-            + ' WHERE ' + searchFieldName + ' LIKE ' + searchText
-            + ' ORDER BY LastViewedDate'
+        if(searchText != null) {
+            searchText = '\'%' + String.escapeSingleQuotes(searchText.trim()) + '%\'';
+            query += ' WHERE ' + searchFieldName + ' LIKE ' + searchText;
+        }
+
+        query += ' ORDER BY LastViewedDate'
             + ' LIMIT ' + limitCount;
+
         System.debug('query=' + query);
 
         List<MatchingRecord> searchResults = new List<MatchingRecord>();
@@ -16,18 +20,17 @@ public with sharing class LookupController {
             MatchingRecord matchingRecord = new MatchingRecord();
             matchingRecord.displayText = String.valueOf(record.get(displayTextFieldName));
             matchingRecord.record      = record;
-            matchingRecord.recordId    = String.valueOf(record.get('Id'));
-            matchingRecord.sobjectName = sobjectName;
+            matchingRecord.sobjectName = parentSObjectName;
             searchResults.add(matchingRecord);
         }
 
+        System.debug(JSON.serialize(searchResults));
         return JSON.serialize(searchResults);
     }
 
     public class MatchingRecord {
         public SObject record     {get;set;}
         public String displayText {get;set;}
-        public String recordId    {get;set;}
         public String sobjectName {get;set;}
     }
 

--- a/src/classes/LookupController.cls-meta.xml
+++ b/src/classes/LookupController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/LookupController_Tests.cls
+++ b/src/classes/LookupController_Tests.cls
@@ -22,7 +22,7 @@ private class LookupController_Tests {
 
         String sobjectName          = 'User';
         String searchFieldName      = 'Name';
-        String searchText           = currentUser.FirstName;
+        String searchText           = currentUser.LastName;
         String displayTextFieldName = 'Name';
         Integer limitCount          = 10;
 

--- a/src/classes/LookupController_Tests.cls
+++ b/src/classes/LookupController_Tests.cls
@@ -1,0 +1,58 @@
+@isTest
+private class LookupController_Tests {
+
+    @isTest
+    static void it_should_return_results_when_no_search_term_provided() {
+        String sobjectName          = 'User';
+        String searchFieldName      = 'Name';
+        String searchText           = null;
+        String displayTextFieldName = 'Name';
+        Integer limitCount          = 10;
+
+        Test.startTest();
+        String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+        List<LookupController.MatchingRecord> userResults = (List<LookupController.MatchingRecord>)JSON.deserialize(searchResultString, List<LookupController.MatchingRecord>.class);
+        System.assert(userResults.size() <= limitCount);
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_return_results_when_search_term_provided() {
+        User currentUser = [SELECT Id, FirstName, LastName, Name FROM User WHERE Id = :UserInfo.getUserId()];
+
+        String sobjectName          = 'User';
+        String searchFieldName      = 'Name';
+        String searchText           = currentUser.FirstName;
+        String displayTextFieldName = 'Name';
+        Integer limitCount          = 10;
+
+        Test.startTest();
+        String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+        List<LookupController.MatchingRecord> userResults = (List<LookupController.MatchingRecord>)JSON.deserialize(searchResultString, List<LookupController.MatchingRecord>.class);
+        System.assert(userResults.size() <= limitCount);
+        for(LookupController.MatchingRecord matchingRecord : userResults) {
+            String recordName = (String)matchingRecord.record.get('Name');
+            System.assert(recordName.contains(searchText));
+        }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_throw_an_exception_for_invalid_sobject() {
+        String sobjectName          = 'FakeObject';
+        String searchFieldName      = 'Name';
+        String searchText           = null;
+        String displayTextFieldName = 'Name';
+        Integer limitCount          = 10;
+
+        Test.startTest();
+        try {
+            String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+            System.assert(false, 'Exception expected here');
+        } catch(Exception ex) {
+            System.assert(ex instanceOf AuraHandledException);
+        }
+        Test.stopTest();
+    }
+
+}

--- a/src/classes/LookupController_Tests.cls
+++ b/src/classes/LookupController_Tests.cls
@@ -10,9 +10,8 @@ private class LookupController_Tests {
         Integer limitCount          = 10;
 
         Test.startTest();
-        String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
-        List<LookupController.MatchingRecord> userResults = (List<LookupController.MatchingRecord>)JSON.deserialize(searchResultString, List<LookupController.MatchingRecord>.class);
-        System.assert(userResults.size() <= limitCount);
+        List<LookupController.MatchingRecord> searchResults = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+        System.assert(searchResults.size() <= limitCount);
         Test.stopTest();
     }
 
@@ -27,10 +26,9 @@ private class LookupController_Tests {
         Integer limitCount          = 10;
 
         Test.startTest();
-        String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
-        List<LookupController.MatchingRecord> userResults = (List<LookupController.MatchingRecord>)JSON.deserialize(searchResultString, List<LookupController.MatchingRecord>.class);
-        System.assert(userResults.size() <= limitCount);
-        for(LookupController.MatchingRecord matchingRecord : userResults) {
+        List<LookupController.MatchingRecord> searchResults = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+        System.assert(searchResults.size() <= limitCount);
+        for(LookupController.MatchingRecord matchingRecord : searchResults) {
             String recordName = (String)matchingRecord.record.get('Name');
             System.assert(recordName.contains(searchText));
         }
@@ -47,11 +45,29 @@ private class LookupController_Tests {
 
         Test.startTest();
         try {
-            String searchResultString = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
+            List<LookupController.MatchingRecord> searchResults = LookupController.search(sobjectName, searchFieldName, searchText, displayTextFieldName, limitCount);
             System.assert(false, 'Exception expected here');
         } catch(Exception ex) {
             System.assert(ex instanceOf AuraHandledException);
         }
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_return_record_based_on_record_id() {
+        Id myUserId = UserInfo.getUserId();
+
+        Test.startTest();
+        LookupController.MatchingRecord recordMatch = LookupController.getRecord(myUserId);
+        System.assertEquals(myUserId, recordMatch.record.Id);
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_return_null_when_record_id_is_null() {
+        Test.startTest();
+        LookupController.MatchingRecord recordMatch = LookupController.getRecord(null);
+        System.assertEquals(null, recordMatch);
         Test.stopTest();
     }
 

--- a/src/classes/LookupController_Tests.cls-meta.xml
+++ b/src/classes/LookupController_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/package.xml
+++ b/src/package.xml
@@ -4,6 +4,7 @@
 		<members>LightningMetadataController</members>
 		<members>LightningMetadataController_Tests</members>
 		<members>LookupController</members>
+		<members>LookupController_Tests</members>
 		<name>ApexClass</name>
 	</types>
 	<types>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>LightningMetadataController</members>
-        <members>LightningMetadataController_Tests</members>
-        <name>ApexClass</name>
-    </types>
-    <types>
-        <members>*</members>
-        <name>AuraDefinitionBundle</name>
-    </types>
-    <version>40.0</version>
+	<types>
+		<members>LightningMetadataController</members>
+		<members>LightningMetadataController_Tests</members>
+		<members>LookupController</members>
+		<name>ApexClass</name>
+	</types>
+	<types>
+		<members>*</members>
+		<name>AuraDefinitionBundle</name>
+	</types>
+	<version>40.0</version>
 </Package>


### PR DESCRIPTION
Fixes #5 - I've created a new lookup component that automatically fetches the sobject & field metadata to render an SLDS lookup. This component will be used indirectly - only inputfield.cmp will be used by devs, but inputField now uses lookup.cmp when the field display type is 'REFERENCE'. This keeps lookup-specific logic and attributes encapsulated/keeps inputField a bit cleaner - if a better lookup solution is ever provided by Salesforce, then lookup.cmp can be easily deleted (as long as only inputField is used by devs and not lookup.cmp directly)